### PR TITLE
Exporting NodeMetadataManager

### DIFF
--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -40,6 +40,7 @@ type NodeMetadata interface {
 	GetWorkerID() string
 }
 
+// NodeMetadataManager ...
 type NodeMetadataManager struct {
 	Zone     string
 	Region   string
@@ -78,14 +79,17 @@ func NewNodeMetadata(nodeName string, logger *zap.Logger) (NodeMetadata, error) 
 	}, nil
 }
 
+// GetZone ...
 func (manager *NodeMetadataManager) GetZone() string {
 	return manager.Zone
 }
 
+// GetRegion ...
 func (manager *NodeMetadataManager) GetRegion() string {
 	return manager.Region
 }
 
+// GetWorkerID ...
 func (manager *NodeMetadataManager) GetWorkerID() string {
 	return manager.WorkerID
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -40,13 +40,13 @@ type NodeMetadata interface {
 	GetWorkerID() string
 }
 
-type nodeMetadataManager struct {
+type NodeMetadataManager struct {
 	zone     string
 	region   string
 	workerID string
 }
 
-var _ NodeMetadata = &nodeMetadataManager{}
+var _ NodeMetadata = &NodeMetadataManager{}
 
 // NewNodeMetadata ...
 func NewNodeMetadata(nodeName string, logger *zap.Logger) (NodeMetadata, error) {
@@ -71,21 +71,21 @@ func NewNodeMetadata(nodeName string, logger *zap.Logger) (NodeMetadata, error) 
 		return nil, errorMsg
 	}
 
-	return &nodeMetadataManager{
+	return &NodeMetadataManager{
 		zone:     nodeLabels[utils.NodeZoneLabel],
 		region:   nodeLabels[utils.NodeRegionLabel],
 		workerID: nodeLabels[utils.NodeWorkerIDLabel],
 	}, nil
 }
 
-func (manager *nodeMetadataManager) GetZone() string {
+func (manager *NodeMetadataManager) GetZone() string {
 	return manager.zone
 }
 
-func (manager *nodeMetadataManager) GetRegion() string {
+func (manager *NodeMetadataManager) GetRegion() string {
 	return manager.region
 }
 
-func (manager *nodeMetadataManager) GetWorkerID() string {
+func (manager *NodeMetadataManager) GetWorkerID() string {
 	return manager.workerID
 }

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -41,9 +41,9 @@ type NodeMetadata interface {
 }
 
 type NodeMetadataManager struct {
-	zone     string
-	region   string
-	workerID string
+	Zone     string
+	Region   string
+	WorkerID string
 }
 
 var _ NodeMetadata = &NodeMetadataManager{}
@@ -72,20 +72,20 @@ func NewNodeMetadata(nodeName string, logger *zap.Logger) (NodeMetadata, error) 
 	}
 
 	return &NodeMetadataManager{
-		zone:     nodeLabels[utils.NodeZoneLabel],
-		region:   nodeLabels[utils.NodeRegionLabel],
-		workerID: nodeLabels[utils.NodeWorkerIDLabel],
+		Zone:     nodeLabels[utils.NodeZoneLabel],
+		Region:   nodeLabels[utils.NodeRegionLabel],
+		WorkerID: nodeLabels[utils.NodeWorkerIDLabel],
 	}, nil
 }
 
 func (manager *NodeMetadataManager) GetZone() string {
-	return manager.zone
+	return manager.Zone
 }
 
 func (manager *NodeMetadataManager) GetRegion() string {
-	return manager.region
+	return manager.Region
 }
 
 func (manager *NodeMetadataManager) GetWorkerID() string {
-	return manager.workerID
+	return manager.WorkerID
 }

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -35,7 +35,7 @@ func TestNewNodeMetadata(t *testing.T) {
 	assert.Nil(t, nodeMeta)
 
 	// statically creating
-	nodeMetadata := &NodeMetadataManager{Zone: "myzone", Region: "myregion", workerID: "myworkerid"}
+	nodeMetadata := &NodeMetadataManager{Zone: "myzone", Region: "myregion", WorkerID: "myworkerid"}
 	assert.Equal(t, "myzone", nodeMetadata.GetZone())
 	assert.Equal(t, "myregion", nodeMetadata.GetRegion())
 	assert.Equal(t, "myworkerid", nodeMetadata.GetWorkerID())

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -35,7 +35,7 @@ func TestNewNodeMetadata(t *testing.T) {
 	assert.Nil(t, nodeMeta)
 
 	// statically creating
-	nodeMetadata := &NodeMetadataManager{zone: "myzone", region: "myregion", workerID: "myworkerid"}
+	nodeMetadata := &NodeMetadataManager{Zone: "myzone", Region: "myregion", workerID: "myworkerid"}
 	assert.Equal(t, "myzone", nodeMetadata.GetZone())
 	assert.Equal(t, "myregion", nodeMetadata.GetRegion())
 	assert.Equal(t, "myworkerid", nodeMetadata.GetWorkerID())

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -35,7 +35,7 @@ func TestNewNodeMetadata(t *testing.T) {
 	assert.Nil(t, nodeMeta)
 
 	// statically creating
-	nodeMetadata := &nodeMetadataManager{zone: "myzone", region: "myregion", workerID: "myworkerid"}
+	nodeMetadata := &NodeMetadataManager{zone: "myzone", region: "myregion", workerID: "myworkerid"}
 	assert.Equal(t, "myzone", nodeMetadata.GetZone())
 	assert.Equal(t, "myregion", nodeMetadata.GetRegion())
 	assert.Equal(t, "myworkerid", nodeMetadata.GetWorkerID())


### PR DESCRIPTION
In ibm-block-csi-driver, we are changing the approach to fetch region from node metadata. For this reason the related Structure needs to be exported. 