### PR TITLE
allow command faking in mounter

### DIFF
--- a/pkg/mountmanager/fake-safe-mounter.go
+++ b/pkg/mountmanager/fake-safe-mounter.go
@@ -76,6 +76,7 @@ func (f *FakeNodeMounter) PathExists(pathname string) (bool, error) {
 }
 
 // NewSafeFormatAndMount ...
-func (f *FakeNodeMounter) NewSafeFormatAndMount() *mount.SafeFormatAndMount {
-	return NewFakeSafeMounter()
+func (f *FakeNodeMounter) GetSafeFormatAndMount() *mount.SafeFormatAndMount {
+	return f.SafeFormatAndMount
+}
 }

--- a/pkg/mountmanager/fake-safe-mounter.go
+++ b/pkg/mountmanager/fake-safe-mounter.go
@@ -21,6 +21,7 @@ import (
 	mount "k8s.io/mount-utils"
 	exec "k8s.io/utils/exec"
 	testExec "k8s.io/utils/exec/testing"
+	testingexec "k8s.io/utils/exec/testing"
 )
 
 // FakeNodeMounter ...
@@ -79,4 +80,61 @@ func (f *FakeNodeMounter) PathExists(pathname string) (bool, error) {
 func (f *FakeNodeMounter) GetSafeFormatAndMount() *mount.SafeFormatAndMount {
 	return f.SafeFormatAndMount
 }
+
+// FakeNodeMounterWithCustomActions ...
+type FakeNodeMounterWithCustomActions struct {
+	*mount.SafeFormatAndMount
+	actionList []testingexec.FakeCommandAction
+}
+
+// NewFakeNodeMounterWithCustomActions ...
+func NewFakeNodeMounterWithCustomActions(actionList []testingexec.FakeCommandAction) Mounter {
+	fakeSafeMounter := NewFakeSafeMounterWithCustomActions(actionList)
+	return &FakeNodeMounterWithCustomActions{fakeSafeMounter, actionList}
+}
+
+// MakeDir ...
+func (f *FakeNodeMounterWithCustomActions) MakeDir(pathname string) error {
+	return nil
+}
+
+// MakeFile ...
+func (f *FakeNodeMounterWithCustomActions) MakeFile(pathname string) error {
+	return nil
+}
+
+// PathExists ...
+func (f *FakeNodeMounterWithCustomActions) PathExists(pathname string) (bool, error) {
+	if pathname == "fake" {
+		return true, nil
+	}
+	return false, nil
+}
+
+// NewSafeFormatAndMount ...
+func (f *FakeNodeMounterWithCustomActions) GetSafeFormatAndMount() *mount.SafeFormatAndMount {
+	return f.SafeFormatAndMount
+}
+
+func NewFakeSafeMounterWithCustomActions(actionList []testingexec.FakeCommandAction) *mount.SafeFormatAndMount {
+	var fakeExec exec.Interface = &testingexec.FakeExec{
+		//DisableScripts: false,
+		//ExactOrder:    true,
+		CommandScript: actionList,
+	}
+
+	fakeMounter := &mount.FakeMounter{MountPoints: []mount.MountPoint{{
+		Device: "devicePath",
+		Path:   "vol-path",
+		Type:   "ext4",
+		Opts:   []string{"defaults"},
+		Freq:   1,
+		Pass:   2,
+	}},
+	}
+
+	return &mount.SafeFormatAndMount{
+		Interface: fakeMounter,
+		Exec:      fakeExec,
+	}
 }

--- a/pkg/mountmanager/mount_linux.go
+++ b/pkg/mountmanager/mount_linux.go
@@ -57,6 +57,6 @@ func (m *NodeMounter) PathExists(path string) (bool, error) {
 }
 
 // NewSafeFormatAndMount returns the new object of SafeFormatAndMount.
-func (m *NodeMounter) NewSafeFormatAndMount() *mount.SafeFormatAndMount {
-	return newSafeMounter()
+func (m *NodeMounter) GetSafeFormatAndMount() *mount.SafeFormatAndMount {
+	return m.SafeFormatAndMount
 }

--- a/pkg/mountmanager/safe-mounter.go
+++ b/pkg/mountmanager/safe-mounter.go
@@ -28,7 +28,7 @@ type mountInterface = mount.Interface
 type Mounter interface {
 	mountInterface
 
-	NewSafeFormatAndMount() *mount.SafeFormatAndMount
+	GetSafeFormatAndMount() *mount.SafeFormatAndMount
 	MakeFile(path string) error
 	MakeDir(path string) error
 	PathExists(path string) (bool, error)


### PR DESCRIPTION
To allow testing VPC block CSI driver we need to improve mounter to allow command faking and prevent re-instantiating the mounter which can delete command fakes mid test. See commit messages for more details on each change.


This is a prerequisite for merging: https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/pull/100