### PR TITLE
Remove sort

### DIFF
--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -936,9 +936,9 @@ if [[ "$e2e_create_new_cluster" == "true" ]]; then
         kube_vers=$(ibmcloud ks versions --show-version $K8S_PLATFORM | grep $PLATFORM_VERSION | awk '{ print $1 }')
     elif [[ "$PLATFORM_VERSION" == "latest" ]]; then
         if [[ "$K8S_PLATFORM" == "openshift" ]]; then
-            versions=($(ibmcloud ks versions --show-version $K8S_PLATFORM  | grep $K8S_PLATFORM | sort))
+            versions=($(ibmcloud ks versions --show-version $K8S_PLATFORM  | grep $K8S_PLATFORM ))
         else
-            versions=($(ibmcloud ks versions --show-version $K8S_PLATFORM  | grep -oE "\b([0-9]{1,2}\.){2}[0-9]{1,2}\b" | sort))
+            versions=($(ibmcloud ks versions --show-version $K8S_PLATFORM  | grep -oE "\b([0-9]{1,2}\.){2}[0-9]{1,2}\b"))
         fi
         count=${#versions[@]}
         kube_vers="${versions[$count - 1]}"


### PR DESCRIPTION
```
ambikanair@Ambikas-MacBook-Pro demo % ibmcloud ks versions
OK
Kubernetes Versions   
1.23.17 (deprecated, unsupported in 20 days)   
1.24.13   
1.25.9 (default)   
1.26.4   
1.27.1   

OpenShift Versions   
4.8.57_openshift (deprecated, unsupported in 17 days)   
4.9.59_openshift   
4.10.56_openshift   
4.11.36_openshift (default)   
4.12.12_openshift   
4.13.0_openshift  
```

`sort` is not required.