### PR TITLE
Add EIT based volume e2e test cases

### DIFF
--- a/tests/e2efile/README.md
+++ b/tests/e2efile/README.md
@@ -6,11 +6,17 @@
 3. Deploy the Driver (with SC)
 4. Export enviornment variables
    ```
-   export E2E_POD_COUNT="1"
-   export E2E_PVC_COUNT="1"
+   # Mandatory
    export GO111MODULE=on
    export GOPATH=<GOPATH>
    export E2E_TEST_RESULT=<absolute-path to a file where the results should be redirected>
+   export TEST_ENV=<stage/prod>
+   export IC_REGION=<us-south>
+   export IC_API_KEY_PROD=<stage/prod API key>
+
+   # Optional
+   export E2E_POD_COUNT="1"
+   export E2E_PVC_COUNT="1"
    ```
 
 5. Test DP2 profile with deployment
@@ -20,4 +26,8 @@
 6. Test volume expansion
    ```
    ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[resize\] \[pv\]"  ./tests/e2efile
+   ```
+7. Test EIT enabled volume test cases
+   ```
+   ginkgo -v -nodes=1 --focus="\[ics-e2e\] \[eit\]"  ./tests/e2efile
    ```

--- a/tests/e2efile/iks-cluster
+++ b/tests/e2efile/iks-cluster
@@ -533,6 +533,23 @@ function check_worker_state {
     return 0
 }
 
+function check_storage_operator_addon {
+    if [[ $# -ne 1 ]]; then
+        echo "${FUNCNAME[0]}: Invalid parameters. Provide cluster name"
+        return 1
+    fi
+
+    cluster_name="$1"
+
+    addon_present=$(ibmcloud ks cluster addon ls -c $cluster_name | grep ibm-storage-operators)
+    if [[ addon_present != "" ]]; then
+        echo "Storage operator enabled in the cluster"
+        return 0
+    fi
+
+    ibmcloud ks cluster addon enable ibm-storage-operator -c $cluster_name
+    sleep 30
+}
 
 function delete_cluster {
     if [[ $# -ne 1 ]]; then
@@ -1060,9 +1077,16 @@ exportKubeConfig $cluster_name; rc=$?
 # From Jenkins there is option to mention addon version and by default FILE CSI driver is not enabled
 # Enable user specified version
 
+# Make sure storage operator is enabled
+check_storage_operator_addon $cluster_name
+
+# Enable file csi driver
 ibmcloud ks cluster addon enable vpc-file-csi-driver --cluster $cluster_name --version $e2e_addon_version
 sleep 30
 check_addon_pod_status ibm-vpc-file-csi-controller
+
+# Enable EIT flag from vpc-file configmap for EIT use cases
+kubectl patch configmap addon-vpc-file-csi-driver-configmap -n kube-system --type merge -p '{"data":{"ENABLE_EIT":"true"}}'
 
 set -x 
 if [[ $rc -ne 0 ]]; then echo -e "Error: Cluster ($cluster_name) export kube config failed!!!" >> $E2E_TEST_SETUP; exit 1; fi


### PR DESCRIPTION
Use case covered
- [x] [ibmc-vpc-file-eit-retain-dp2] create pv, pvc, deployment resources. Write and read to volume; delete the pod; write and read to volume again
- [x] [ibmc-vpc-file-eit-dp2] should create pv, pvc, daemonSet resources. Write and read to volume.
- [x] should create pv, pvc and pod resources, and resize the volume

-----------------

With file GA, file driver resources will be created by `ibm-storage-operator` addon which will be enabled by default. So following things needs to be added before running all tests:
- [x] Make sure `ibm-storage-operator` addon is enabled
- [x] For EIT test cases: make sure to run command 'kubectl edit configmap addon-vpc-file-csi-driver-configmap -n kube-system' and set 'ENABLE_EIT' flag to 'true'

-----------------

Testing:
- TBD once EIT changes are available in pre-prod