### PR TITLE
Allow transitEncryption option for mount

### DIFF
--- a/pkg/mountmanager/fake-safe-mounter.go
+++ b/pkg/mountmanager/fake-safe-mounter.go
@@ -31,7 +31,7 @@ type FakeNodeMounter struct {
 }
 
 // MountEITBasedFileShare implements Mounter.
-func (*FakeNodeMounter) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, requestID string) (string, error) {
+func (*FakeNodeMounter) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, transitEncryption string, requestID string) (string, error) {
 	return "", nil
 }
 
@@ -97,7 +97,7 @@ type FakeNodeMounterWithCustomActions struct {
 }
 
 // MountEITBasedFileShare implements Mounter.
-func (*FakeNodeMounterWithCustomActions) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, requestID string) (string, error) {
+func (*FakeNodeMounterWithCustomActions) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, transitEncryption string, requestID string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/mountmanager/mount_linux.go
+++ b/pkg/mountmanager/mount_linux.go
@@ -46,9 +46,9 @@ const (
 )
 
 // MountEITBasedFileShare mounts EIT based FileShare on host system
-func (m *NodeMounter) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, requestID string) (string, error) {
+func (m *NodeMounter) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, transitEncryption string, requestID string) (string, error) {
 	// Create payload
-	payload := fmt.Sprintf(`{"mountPath":"%s","targetPath":"%s","fsType":"%s","requestID":"%s"}`, mountPath, targetPath, fsType, requestID)
+	payload := fmt.Sprintf(`{"mountPath":"%s","targetPath":"%s","fsType":"%s","transitEncryption":"%s","requestID":"%s"}`, mountPath, targetPath, fsType, transitEncryption, requestID)
 	errResponse, err := createMountHelperContainerRequest(payload, urlMountPath)
 
 	if err != nil {

--- a/pkg/mountmanager/mount_unsupported.go
+++ b/pkg/mountmanager/mount_unsupported.go
@@ -54,6 +54,6 @@ func (m *NodeMounter) Resize(devicePath string, deviceMountPath string) (bool, e
 }
 
 // MountEITBasedFileShare ...
-func (m *NodeMounter) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, requestID string) (string, error) {
+func (m *NodeMounter) MountEITBasedFileShare(mountPath string, targetPath string, fsType string, transitEncryption string, requestID string) (string, error) {
 	return "", nil
 }

--- a/pkg/mountmanager/safe-mounter.go
+++ b/pkg/mountmanager/safe-mounter.go
@@ -28,7 +28,7 @@ type mountInterface = mount.Interface
 type Mounter interface {
 	mountInterface
 
-	MountEITBasedFileShare(mountPath string, targetPath string, fsType string, requestID string) (string, error)
+	MountEITBasedFileShare(mountPath string, targetPath string, fsType string, transitEncryption string, requestID string) (string, error)
 	GetSafeFormatAndMount() *mount.SafeFormatAndMount
 	MakeFile(path string) error
 	MakeDir(path string) error


### PR DESCRIPTION
For `MountEITBasedFileShare` have added parameter `transitEncryption` which can used to decide is it ipsec of stunnel based