### PR TITLE
Replatforming changes addition

### DIFF
--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -217,10 +217,17 @@ echo "Exit status for xfs storage class resize volume test: $rc4"
 
 set -x
 VA_ADDON_VERSION=5.2
-CLUSTER_ADDON_MAJOR=$(echo "$CLUSTER_ADDON_VER" | awk -F'.' '{print $1"."$2}')
-compare=`echo | awk "{ print ($CLUSTER_ADDON_MAJOR >= $VA_ADDON_VERSION)?1 : 0 }"`
-echo $compare
-if [[ $compare -eq 1 ]]; then
+CLUSTER_ADDON_MAJOR=$(echo "$CLUSTER_ADDON_VER" | sed -E 's/^v//' | awk -F'.' '{print $1"."$2}')
+echo "Normalized add-on major.minor version: $CLUSTER_ADDON_MAJOR"
+
+# version check
+version_ge() {
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+rc5=${rc5:-0}
+rc6=${rc6:-0}
+if version_ge "$CLUSTER_ADDON_MAJOR" "$VA_ADDON_VERSION"; then
 	ginkgo -v --focus="\[ics-e2e\] \[volume-attachment-limit\] \[default\]" ./tests/e2e
 	rc5=$?
 	echo "Exit status for default attach-volume test: $rc5"
@@ -229,11 +236,6 @@ if [[ $compare -eq 1 ]]; then
 	rc6=$?
 	echo "Exit status for configmap related attach-volume test: $rc6"
 fi
-
-#version check
-version_ge() {
-    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
-}
 
 # Acadia Profile based tests
 rc7=${rc7:-0}

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -841,8 +841,6 @@ fi
 # Login to IBM Cloud
 echo "==========LOGGING INTO IBMCLOUD=============="
 IC_REGION="$e2e_ic_region"
-
-
 echo "------- REGION $IC_REGION---------"
 set +x
 if [[ -z "$E2ETEST_API_KEY" ]]; then
@@ -863,6 +861,7 @@ if [[ $rc -ne 0 ]]; then
    exit 1
 fi
 
+ibmcloud target -r "$IC_REGION"
 
 if [ -z "$IC_REGION" ]; then
   echo "ERROR: IC_REGION is not set"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -840,7 +840,9 @@ fi
 
 # Login to IBM Cloud
 echo "==========LOGGING INTO IBMCLOUD=============="
-IC_REGION="$e2e_ic_region"
+#IC_REGION="$e2e_ic_region"
+
+
 echo "------- REGION $IC_REGION---------"
 set +x
 if [[ -z "$E2ETEST_API_KEY" ]]; then
@@ -860,6 +862,9 @@ if [[ $rc -ne 0 ]]; then
    echo -e "Error: Invalid option \"-r $e2e_ic_region\"!!!" >> $E2E_TEST_SETUP
    exit 1
 fi
+
+IC_REGION="$e2e_ic_region"
+
 # #assign region if env == stage-us-south
 # if [[ "$e2e_env" == "stage-us-south" ]]; then
 #     IC_REGION="us-south"                 # REAL REGION

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -836,6 +836,8 @@ fi
 
 # Login to IBM Cloud
 echo "==========LOGGING INTO IBMCLOUD=============="
+IC_REGION="$e2e_ic_region"
+echo "------- REGION $IC_REGION---------"
 set +x
 if [[ -z "$E2ETEST_API_KEY" ]]; then
     if [[ "$e2e_env" = "stage" || "$e2e_env" = "stage-us-south" ]]; then
@@ -858,7 +860,7 @@ fi
 if [[ "$e2e_env" == "stage-us-south" ]]; then
     e2e_ic_region="us-south-ngdc-test"
 fi
-IC_REGION="$e2e_ic_region"
+
 ibmcloud target -r "$IC_REGION"
 
 echo "----- ic ks init -----"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -1053,6 +1053,7 @@ if [[ "$e2e_create_new_cluster" == "true" ]]; then
     # Create cluster
     random_string=$(date +%s | cksum | base64 | head -c 8 | awk '{print tolower($0)}')
     cluster_name="${CLUSTER_NAME_SUFFIX}-${random_string}"
+    e2e_cluster_name="$cluster_name"
     if [[ -n "$e2e_var_exports" ]]; then
 	echo "CLUSTER_NAME=$cluster_name" >> $e2e_var_exports
 	echo "CLUSTER_KUBE_VER=$kube_vers" >> $e2e_var_exports

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -1024,7 +1024,9 @@ fi
 # Resolve KS API endpoint
 if [[ -n "$E2ETEST_CS_API_EP" ]]; then
     KS_HOST="$E2ETEST_CS_API_EP"
-elif [[ "$e2e_env" == "stage" || "$e2e_env" == "stage-us-south" ]]; then
+elif [[ "$e2e_env" == "stage-us-south" ]]; then
+    KS_HOST="https://stage-us-south.containers.test.cloud.ibm.com"
+elif [[ "$e2e_env" == "stage" ]]; then
     KS_HOST="https://containers.test.cloud.ibm.com"
 else
     KS_HOST="https://containers.cloud.ibm.com"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -857,7 +857,7 @@ if [[ $rc -ne 0 ]]; then
    exit 1
 fi
 # assign region if env == stage-us-south
-if [[ "$e2e_env" != "stage-us-south" ]]; then
+if [[ "$e2e_env" == "stage-us-south" ]]; then
     e2e_ic_region="us-south-ngdc-test"
 fi
 IC_REGION="$e2e_ic_region"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -792,7 +792,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [[ -z "$IC_API_KEY_PROD" && -z "$IC_API_KEY_STAG"  ]]; then echo -e "Error: E2ETEST_API_KEY not set!!!" >> $E2E_TEST_SETUP; exit 1;  fi
 
 E2ETEST_MZ="$e2e_mz"
-if [[ "$e2e_env" != "prod" && "$e2e_env" != "stage" ]]; then
+if [[ "$e2e_env" != "prod" && "$e2e_env" != "stage" && "$e2e_env" != "stage-us-south" ]]; then
 	echo -e "Error: Invalid option \"-e $e2e_env\"!!!" >> $E2E_TEST_SETUP
 	exit 1
 fi

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -290,7 +290,7 @@ function createSubnet {
 			echo -e "Error: [$subnet_name] Subnet creation failed!!!" >> $E2E_TEST_SETUP
 			return 2
 		fi
-		echo "Info: Created Subner [$subnet_name ($subnet_id)]..."
+		echo "Info: Created Subnet [$subnet_name ($subnet_id)]..."
 	else
 		echo -e "Error: [$subnet_name] Subnet already exist!!!" >> $E2E_TEST_SETUP
 		return 1
@@ -838,9 +838,23 @@ if [[ "$PRIMARY_ZONE_ID" == "$SECOND_ZONE_ID" ]]; then
    exit 1
 fi
 
+# Resolve final region
+if [[ "$e2e_env" == "stage-us-south" ]]; then
+    IC_REGION="us-south-ngdc-test"
+    # Set default test flavor only if not explicitly set
+    WORKER_NODE_FLAVOR="bx3d.4x20"
+else
+    IC_REGION="$e2e_ic_region"
+fi
+
+if [[ -z "$IC_REGION" ]]; then
+    echo "ERROR: Region not set"
+    exit 1
+fi
+
 # Login to IBM Cloud
 echo "==========LOGGING INTO IBMCLOUD=============="
-IC_REGION="$e2e_ic_region"
+#IC_REGION="$e2e_ic_region"
 echo "------- REGION $IC_REGION---------"
 set +x
 if [[ -z "$E2ETEST_API_KEY" ]]; then
@@ -868,14 +882,7 @@ if [ -z "$IC_REGION" ]; then
   exit 1
 fi
 
-# Resolve final region
-if [[ "$e2e_env" == "stage-us-south" ]]; then
-    IC_REGION="us-south-ngdc-test"
-    # Set default test flavor only if not explicitly set
-    WORKER_NODE_FLAVOR="bx3d.4x20"
-else
-    IC_REGION="$e2e_ic_region"
-fi
+
 
 # echo "----- ic ks init -----"
 # if [[ "$e2e_env" = "stage" ]]; then
@@ -933,7 +940,7 @@ if [[ "$e2e_cluster_delete" == "true" ]]; then
    fi
    check_cluster_deleted $cluster_name; rc=$?
    if [[ $rc -ne 0 ]]; then echo -e "Error: Cluster ($cluster_name) check delete status failed!!!" >> $E2E_TEST_SETUP; exit 1; fi
-   e2e_cluster_delete="fasle"
+   e2e_cluster_delete="false"
    exit 0
 fi
 

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -906,6 +906,10 @@ if [[ -n "$E2ETEST_CS_API_EP" ]]; then
     KS_HOST="$E2ETEST_CS_API_EP"
 elif [[ "$e2e_env" == "stage" || "$e2e_env" == "stage-us-south" ]]; then
     KS_HOST="https://containers.test.cloud.ibm.com"
+elif [[ "$e2e_env" == "stage-us-south" ]]; then
+    KS_HOST="https://stage-us-south.containers.test.cloud.ibm.com"
+elif [[ "$IC_REGION" == "ca-mon" ]]; then
+    KS_HOST="https://ca-mon.containers.cloud.ibm.com"
 else
     KS_HOST="https://containers.cloud.ibm.com"
 fi

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -904,7 +904,7 @@ ibmcloud target -r "$IC_REGION"
 
 if [[ -n "$E2ETEST_CS_API_EP" ]]; then
     KS_HOST="$E2ETEST_CS_API_EP"
-elif [[ "$e2e_env" == "stage" || "$e2e_env" == "stage-us-south" ]]; then
+elif [[ "$e2e_env" == "stage" ]]; then
     KS_HOST="https://containers.test.cloud.ibm.com"
 elif [[ "$e2e_env" == "stage-us-south" ]]; then
     KS_HOST="https://stage-us-south.containers.test.cloud.ibm.com"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -886,21 +886,37 @@ ibmcloud regions | grep -w "$IC_REGION" > /dev/null || {
 
 ibmcloud target -r "$IC_REGION"
 
-echo "----- ic ks init -----"
-if [[ "$e2e_env" = "stage" ]]; then
-    E2ETEST_CS_API_EP="https://test.cloud.ibm.com"
-    E2ETEST_IC_RES_GRP="Default"
-    ibmcloud ks init --host $E2ETEST_CS_API_EP
-elif [[ "$e2e_env" = "stage-us-south" ]]; then
-    E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
-    E2ETEST_IC_RES_GRP="Default"
-    ibmcloud ks init --host $E2ETEST_CS_API_EP
-elif [[ "$IC_REGION" == "ca-mon" ]]; then
-   ibmcloud ks init --host https://ca-mon.containers.cloud.ibm.com
-   WORKER_NODE_FLAVOR=${E2ETEST_NODE_FLAVOR:-bx3d.4x20}
+# echo "----- ic ks init -----"
+# if [[ "$e2e_env" = "stage" ]]; then
+#     E2ETEST_CS_API_EP="https://test.cloud.ibm.com"
+#     E2ETEST_IC_RES_GRP="Default"
+#     ibmcloud ks init --host $E2ETEST_CS_API_EP
+# elif [[ "$e2e_env" = "stage-us-south" ]]; then
+#     E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
+#     E2ETEST_IC_RES_GRP="Default"
+#     ibmcloud ks init --host $E2ETEST_CS_API_EP
+# elif [[ "$IC_REGION" == "ca-mon" ]]; then
+#    ibmcloud ks init --host https://ca-mon.containers.cloud.ibm.com
+#    WORKER_NODE_FLAVOR=${E2ETEST_NODE_FLAVOR:-bx3d.4x20}
+# else
+#    ibmcloud ks init --host https://containers.cloud.ibm.com
+# fi
+
+if [[ -n "$E2ETEST_CS_API_EP" ]]; then
+    KS_HOST="$E2ETEST_CS_API_EP"
+elif [[ "$e2e_env" == "stage" || "$e2e_env" == "stage-us-south" ]]; then
+    KS_HOST="https://containers.test.cloud.ibm.com"
 else
-   ibmcloud ks init --host https://containers.cloud.ibm.com
+    KS_HOST="https://containers.cloud.ibm.com"
 fi
+
+if [[ -z "$KS_HOST" ]]; then
+    echo "ERROR: KS_HOST is empty" >> $E2E_TEST_SETUP
+    exit 1
+fi
+
+echo "KS endpoint : $KS_HOST"
+ibmcloud ks init --host "$KS_HOST"
 
 if [[ $IC_PROVIDER == "vpc-gen2" ]] ; then
    ibmcloud is target --gen 2

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -822,6 +822,7 @@ if [[ "$e2e_env" = "stage" ]]; then
 elif [[ "$e2e_env" = "stage-us-south" ]]; then
     E2ETEST_IC_API_EP="https://test.cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
+    E2ETEST_IC_RES_GRP="Default"
 else
     E2ETEST_IC_API_EP="https://cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://containers.cloud.ibm.com"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -106,6 +106,37 @@ function updateCertPathInKubeConfig {
     echo "Info: Updated cert paths in KUBECONFIG..."
 }
 
+function check_kube_nodes_ready {
+    if [[ $# -ne 1 ]]; then
+        echo "${FUNCNAME[0]}: Invalid parameter. Provide cluster name"
+        return 1
+    fi
+
+    local cluster_name=$1
+    local timeout=${KUBE_NODE_STATE_TIMEOUT:-20}
+    local node_count=0
+    local ready_count=0
+
+    echo "Info: [$cluster_name] Checking Kubernetes node registration..."
+
+    for ((i=1; i<=timeout; i++)); do
+        node_count=$(kubectl get nodes --no-headers 2>/dev/null | wc -l | xargs)
+        ready_count=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 ~ /^Ready/ {count++} END {print count+0}')
+
+        if [[ $node_count -gt 0 && $ready_count -eq $node_count ]]; then
+            echo "Info: [$cluster_name] Kubernetes nodes are Ready [$ready_count/$node_count]"
+            return 0
+        fi
+
+        echo "Info: [$cluster_name] Kubernetes nodes Ready => [$ready_count/$node_count]...[$i/$timeout]"
+        sleep $SLEEP_TIME
+    done
+
+    echo "Error: [$cluster_name] Kubernetes nodes did not become Ready in $timeout minutes."
+    kubectl get nodes -o wide || true
+    return 2
+}
+
 function normalize_addon_version_for_platform {
     local requested_version="$1"
     local version_no_prefix
@@ -511,7 +542,6 @@ function check_worker_state {
         return 1
     fi
 
-    workers_in_desiredstat=0
     cluster_name=$1
 
     TIMEOUT=${WORKER_STATE_TIMEOUT:-90}
@@ -523,6 +553,7 @@ function check_worker_state {
 
     # Try for up to 90 minutes(default) for the workers to reach deployed state
     for ((i=1; i<=TIMEOUT; i++)); do
+        workers_in_desiredstat=0
         oldifs="$IFS"
         IFS=$'\n'
         if [[ $E2ETEST_MZ == "true" ]]; then
@@ -532,6 +563,13 @@ function check_worker_state {
         fi
         IFS="$oldifs"
         worker_cnt=${#workers[@]}
+
+        if [[ $worker_cnt -eq 0 ]]; then
+            echo "Info: [$cluster_name] no workers found yet...[$i/$TIMEOUT]"
+            ibmcloud ks worker ls --cluster $cluster_name || true
+            sleep $SLEEP_TIME
+            continue
+        fi
 
         # Inspect the state of each worker
         for worker in "${workers[@]}"; do
@@ -568,12 +606,15 @@ function check_worker_state {
             status_msg="Info: [$workers_in_desiredstat / $worker_cnt] $cluster_name workers are in deployed state"
             echo "$status_msg"
             sleep $SLEEP_TIME
-            workers_in_desiredstat=0
         fi
     done
 
     # Ignore failures on this command call
     ibmcloud ks worker ls --cluster $cluster_name || true
+    if [[ $worker_cnt -eq 0 ]]; then
+        echo "Error: No workers found for [$cluster_name] within $TIMEOUT minutes."
+        return 2
+    fi
     if [[ $worker_cnt -ne $workers_in_desiredstat ]]; then
         echo "Error: Not all [$cluster_name] workers reached deployed state in $TIMEOUT  minutes."
         return 2
@@ -1184,6 +1225,10 @@ else
 fi
 
 exportKubeConfig $cluster_name; rc=$?
+if [[ $rc -eq 0 ]]; then
+    check_kube_nodes_ready $cluster_name; rc=$?
+fi
+if [[ $rc -ne 0 ]]; then echo -e "Error: Cluster ($cluster_name) Kubernetes node check failed!!!" >> $E2E_TEST_SETUP; exit 1; fi
 
 # From Jenkins there is option to mention addon version. 
 # So if value is not "default", disable and enable user specified version

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -792,7 +792,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [[ -z "$IC_API_KEY_PROD" && -z "$IC_API_KEY_STAG"  ]]; then echo -e "Error: E2ETEST_API_KEY not set!!!" >> $E2E_TEST_SETUP; exit 1;  fi
 
 E2ETEST_MZ="$e2e_mz"
-if [[ "$e2e_env" != "prod" && "$e2e_env" != "stage" ]]; then
+if [[ "$e2e_env" != "prod" && "$e2e_env" != "stage" &&  "$e2e_env" != "stage-us-south" ]]; then
 	echo -e "Error: Invalid option \"-e $e2e_env\"!!!" >> $E2E_TEST_SETUP
 	exit 1
 fi
@@ -819,6 +819,9 @@ if [[ "$e2e_env" = "stage" ]]; then
     E2ETEST_IC_API_EP="https://test.cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://containers.test.cloud.ibm.com"
     E2ETEST_IC_RES_GRP="Default"
+elif [[ "$e2e_env" = "stage-us-south" ]]; then
+    E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
+    E2ETEST_IC_RES_GRP="Default"
 else
     E2ETEST_IC_API_EP="https://cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://containers.cloud.ibm.com"
@@ -837,7 +840,7 @@ fi
 # Login to IBM Cloud
 set +x
 if [[ -z "$E2ETEST_API_KEY" ]]; then
-    if [[ "$e2e_env" = "stage" ]]; then
+    if [[ "$e2e_env" = "stage" || "$e2e_env" = "stage-us-south" ]]; then
         ibmcloud login -a $E2ETEST_IC_API_EP --apikey ${IC_API_KEY_STAG} -r $IC_REGION -g $E2ETEST_IC_RES_GRP; rc=$?
     else
         ibmcloud login -a $E2ETEST_IC_API_EP --apikey ${IC_API_KEY_PROD} -r $IC_REGION -g $E2ETEST_IC_RES_GRP; rc=$?
@@ -847,10 +850,15 @@ else
 fi
 if [[ $rc -ne 0 ]]; then echo -e "Error: IBM Cloud Login failed!!!" >> $E2E_TEST_SETUP; exit 1; fi
 
+# target the region
 ibmcloud regions | grep -w "$e2e_ic_region" > /dev/null; rc=$?
 if [[ $rc -ne 0 ]]; then
    echo -e "Error: Invalid option \"-r $e2e_ic_region\"!!!" >> $E2E_TEST_SETUP
    exit 1
+fi
+# assign region if env == stage-us-south
+if [[ "$e2e_env" != "stage-us-south" ]]; then
+    e2e_ic_region="us-south-ngdc-test"
 fi
 IC_REGION="$e2e_ic_region"
 ibmcloud target -r "$IC_REGION"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -882,8 +882,6 @@ if [ -z "$IC_REGION" ]; then
   exit 1
 fi
 
-
-
 # echo "----- ic ks init -----"
 # if [[ "$e2e_env" = "stage" ]]; then
 #     E2ETEST_CS_API_EP="https://test.cloud.ibm.com"

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -858,13 +858,13 @@ if [[ $rc -ne 0 ]]; then
 fi
 #assign region if env == stage-us-south
 if [[ "$e2e_env" == "stage-us-south" ]]; then
-    IC_REGION="us-south-ngdc-test"
-    # Set default test flavor only if not explicitly set
+    IC_REGION="us-south"                 # REAL REGION
+    ZONE_PREFIX="us-south-ngdc-test"     # ZONE PREFIX
     WORKER_NODE_FLAVOR="bx3d.4x20"
 else
     IC_REGION="$e2e_ic_region"
+    ZONE_PREFIX="$IC_REGION"
 fi
-
 # Validate the final region
 ibmcloud regions | grep -w "$IC_REGION" > /dev/null || {
    echo -e "Error: Invalid region \"$IC_REGION\"!!!" >> $E2E_TEST_SETUP

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -1160,7 +1160,15 @@ exportKubeConfig $cluster_name; rc=$?
 # From Jenkins there is option to mention addon version. 
 # So if value is not "default", disable and enable user specified version
 if [[ $e2e_addon_version != "default"  ]]; then
-        echo "Info: Installing addon $ADDON_VERSION"
+        # For 5.1.x, ensure correct platform suffix (_iks for kubernetes, _ocp for openshift)
+        if [[ "$e2e_addon_version" == *"_iks"* || "$e2e_addon_version" == *"_ocp"* ]]; then
+            if [[ "$K8S_PLATFORM" == "openshift" ]]; then
+                e2e_addon_version=$(echo "$e2e_addon_version" | sed 's/_iks$/_ocp/')
+            else
+                e2e_addon_version=$(echo "$e2e_addon_version" | sed 's/_ocp$/_iks/')
+            fi
+        fi
+        echo "Info: Installing addon $e2e_addon_version"
         ibmcloud ks cluster addon disable vpc-block-csi-driver -f --cluster $cluster_name
         sleep 900
         ibmcloud ks cluster addon enable vpc-block-csi-driver --cluster $cluster_name --version $e2e_addon_version

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -840,7 +840,7 @@ fi
 
 # Login to IBM Cloud
 echo "==========LOGGING INTO IBMCLOUD=============="
-#IC_REGION="$e2e_ic_region"
+IC_REGION="$e2e_ic_region"
 
 
 echo "------- REGION $IC_REGION---------"
@@ -863,22 +863,11 @@ if [[ $rc -ne 0 ]]; then
    exit 1
 fi
 
-IC_REGION="$e2e_ic_region"
 
 if [ -z "$IC_REGION" ]; then
   echo "ERROR: IC_REGION is not set"
   exit 1
 fi
-
-# #assign region if env == stage-us-south
-# if [[ "$e2e_env" == "stage-us-south" ]]; then
-#     IC_REGION="us-south"                 # REAL REGION
-#     ZONE_PREFIX="us-south-ngdc-test"     # ZONE PREFIX
-#     WORKER_NODE_FLAVOR="bx3d.4x20"
-# else
-#     IC_REGION="$e2e_ic_region"
-#     ZONE_PREFIX="$IC_REGION"
-# fi
 
 # Resolve final region
 if [[ "$e2e_env" == "stage-us-south" ]]; then
@@ -888,14 +877,6 @@ if [[ "$e2e_env" == "stage-us-south" ]]; then
 else
     IC_REGION="$e2e_ic_region"
 fi
-
-# Validate the final region
-ibmcloud regions | grep -w "$IC_REGION" > /dev/null || {
-   echo -e "Error: Invalid region \"$IC_REGION\"!!!" >> $E2E_TEST_SETUP
-   exit 1
-}
-
-ibmcloud target -r "$IC_REGION"
 
 # echo "----- ic ks init -----"
 # if [[ "$e2e_env" = "stage" ]]; then
@@ -913,14 +894,11 @@ ibmcloud target -r "$IC_REGION"
 #    ibmcloud ks init --host https://containers.cloud.ibm.com
 # fi
 
+# Resolve KS API endpoint
 if [[ -n "$E2ETEST_CS_API_EP" ]]; then
     KS_HOST="$E2ETEST_CS_API_EP"
-elif [[ "$e2e_env" == "stage" ]]; then
+elif [[ "$e2e_env" == "stage" || "$e2e_env" == "stage-us-south" ]]; then
     KS_HOST="https://containers.test.cloud.ibm.com"
-elif [[ "$e2e_env" == "stage-us-south" ]]; then
-    KS_HOST="https://stage-us-south.containers.test.cloud.ibm.com"
-elif [[ "$IC_REGION" == "ca-mon" ]]; then
-    KS_HOST="https://ca-mon.containers.cloud.ibm.com"
 else
     KS_HOST="https://containers.cloud.ibm.com"
 fi

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -856,10 +856,10 @@ if [[ $rc -ne 0 ]]; then
    echo -e "Error: Invalid option \"-r $e2e_ic_region\"!!!" >> $E2E_TEST_SETUP
    exit 1
 fi
-# assign region if env == stage-us-south
-# if [[ "$e2e_env" == "stage-us-south" ]]; then
-#     e2e_ic_region="us-south-ngdc-test"
-# fi
+#assign region if env == stage-us-south
+if [[ "$e2e_env" == "stage-us-south" ]]; then
+    e2e_ic_region="us-south-ngdc-test"
+fi
 
 ibmcloud target -r "$IC_REGION"
 
@@ -868,10 +868,10 @@ if [[ "$e2e_env" = "stage" ]]; then
     E2ETEST_CS_API_EP="https://test.cloud.ibm.com"
     E2ETEST_IC_RES_GRP="Default"
     ibmcloud ks init --host $E2ETEST_CS_API_EP
-# elif [[ "$e2e_env" = "stage-us-south" ]]; then
-#     E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
-#     E2ETEST_IC_RES_GRP="Default"
-#     ibmcloud ks init --host $E2ETEST_CS_API_EP
+elif [[ "$e2e_env" = "stage-us-south" ]]; then
+    E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
+    E2ETEST_IC_RES_GRP="Default"
+    ibmcloud ks init --host $E2ETEST_CS_API_EP
 elif [[ "$IC_REGION" == "ca-mon" ]]; then
    ibmcloud ks init --host https://ca-mon.containers.cloud.ibm.com
    WORKER_NODE_FLAVOR=${E2ETEST_NODE_FLAVOR:-bx3d.4x20}

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -990,6 +990,9 @@ if [[ "$e2e_create_new_cluster" == "true" ]]; then
 
     if [[ -n "$E2ETEST_NODE_FLAVOR" ]]; then
         WORKER_NODE_FLAVOR="$E2ETEST_NODE_FLAVOR"
+    elif [[ "$e2e_env" == "stage-us-south" ]]; then
+        # Force correct flavor for ngdc-test
+        WORKER_NODE_FLAVOR="bx3d.4x20"
     else
         var_flvr="FLAVOR_${IC_PROVIDER//-/_}"
         WORKER_NODE_FLAVOR=${!var_flvr}

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -858,8 +858,18 @@ if [[ $rc -ne 0 ]]; then
 fi
 #assign region if env == stage-us-south
 if [[ "$e2e_env" == "stage-us-south" ]]; then
-    e2e_ic_region="us-south-ngdc-test"
+    IC_REGION="us-south-ngdc-test"
+    # Set default test flavor only if not explicitly set
+    WORKER_NODE_FLAVOR="bx3d.4x20"
+else
+    IC_REGION="$e2e_ic_region"
 fi
+
+# Validate the final region
+ibmcloud regions | grep -w "$IC_REGION" > /dev/null || {
+   echo -e "Error: Invalid region \"$IC_REGION\"!!!" >> $E2E_TEST_SETUP
+   exit 1
+}
 
 ibmcloud target -r "$IC_REGION"
 
@@ -1053,6 +1063,7 @@ if [[ "$e2e_create_new_cluster" == "true" ]]; then
     # Create cluster
     random_string=$(date +%s | cksum | base64 | head -c 8 | awk '{print tolower($0)}')
     cluster_name="${CLUSTER_NAME_SUFFIX}-${random_string}"
+    cluster_name=${cluster_name:0:32}
     e2e_cluster_name="$cluster_name"
     if [[ -n "$e2e_var_exports" ]]; then
 	echo "CLUSTER_NAME=$cluster_name" >> $e2e_var_exports

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -865,6 +865,11 @@ fi
 
 IC_REGION="$e2e_ic_region"
 
+if [ -z "$IC_REGION" ]; then
+  echo "ERROR: IC_REGION is not set"
+  exit 1
+fi
+
 # #assign region if env == stage-us-south
 # if [[ "$e2e_env" == "stage-us-south" ]]; then
 #     IC_REGION="us-south"                 # REAL REGION

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -139,8 +139,7 @@ function check_kube_nodes_ready {
 
 function normalize_addon_version_for_platform {
     local requested_version="$1"
-    local version_no_prefix
-    local version_core
+    local version_clean
     local major_minor
 
     if [[ -z "$requested_version" || "$requested_version" == "default" ]]; then
@@ -148,21 +147,78 @@ function normalize_addon_version_for_platform {
         return 0
     fi
 
-    version_no_prefix=$(echo "$requested_version" | sed -E 's/^v//')
-    version_core=$(echo "$version_no_prefix" | sed -E 's/(_iks|_ocp)$//')
-    major_minor=$(echo "$version_core" | awk -F'.' '{print $1"."$2}')
+    # The enable API accepts channel versions like 5.1/5.2. Running controller
+    # annotations may still include build/platform suffixes like v5.1.47_ocp.
+    version_clean=$(echo "$requested_version" | sed -E 's/^v//; s/(_iks|_ocp)$//')
+    major_minor=$(echo "$version_clean" | awk -F'.' '{print $1"."$2}')
 
-    # 5.1 uses platform-specific addon suffixes, while 5.2 and later do not.
-    if [[ "$major_minor" == "5.1" ]]; then
-        if [[ "$K8S_PLATFORM" == "openshift" ]]; then
-            echo "${version_core}_ocp"
-        else
-            echo "${version_core}_iks"
-        fi
+    if [[ "$major_minor" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        echo "$major_minor"
         return 0
     fi
 
-    echo "$version_core"
+    echo "$version_clean"
+}
+
+function flavor_available_in_zone {
+    if [[ $# -ne 2 ]]; then
+        echo "${FUNCNAME[0]}: Invalid parameters. Provide zone and flavor"
+        return 1
+    fi
+
+    local zone_name="$1"
+    local requested_flavor="$2"
+
+    ibmcloud ks flavors --zone "$zone_name" 2>/dev/null | \
+        awk '$1 ~ /^[a-z0-9.-]+$/ && $1 ~ /[0-9]/ {print $1}' | \
+        grep -Fx "$requested_flavor" >/dev/null
+}
+
+function resolve_worker_node_flavor {
+    if [[ $# -lt 2 ]]; then
+        echo "${FUNCNAME[0]}: Invalid parameters. Provide preferred flavor and at least one zone"
+        return 1
+    fi
+
+    local preferred_flavor="$1"
+    shift
+
+    local candidate=""
+    local zone_name=""
+    local supported="false"
+    local candidates=("$preferred_flavor")
+
+    if [[ "$K8S_PLATFORM" == "openshift" ]]; then
+        candidates+=("bx3d.4x20" "bx2.4x16" "bx2d.4x16")
+    else
+        candidates+=("bx2.4x16" "bx3d.4x20" "bx2d.4x16")
+    fi
+
+    for candidate in "${candidates[@]}"; do
+        [[ -z "$candidate" ]] && continue
+
+        supported="true"
+        for zone_name in "$@"; do
+            [[ -z "$zone_name" ]] && continue
+            if ! flavor_available_in_zone "$zone_name" "$candidate"; then
+                supported="false"
+                break
+            fi
+        done
+
+        if [[ "$supported" == "true" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "Error: No supported worker flavor found for zones [$*]." >> $E2E_TEST_SETUP
+    for zone_name in "$@"; do
+        [[ -z "$zone_name" ]] && continue
+        echo "Info: Available flavors for zone [$zone_name]..." >> $E2E_TEST_SETUP
+        ibmcloud ks flavors --zone "$zone_name" >> $E2E_TEST_SETUP 2>&1 || true
+    done
+    return 2
 }
 
 function create_vlan_cls {
@@ -938,13 +994,11 @@ fi
 if [[ $rc -ne 0 ]]; then echo -e "Error: IBM Cloud Login failed!!!" >> $E2E_TEST_SETUP; exit 1; fi
 
 # target the region
-ibmcloud regions | grep -w "$e2e_ic_region" > /dev/null; rc=$?
+ibmcloud target -r "$IC_REGION"; rc=$?
 if [[ $rc -ne 0 ]]; then
-   echo -e "Error: Invalid option \"-r $e2e_ic_region\"!!!" >> $E2E_TEST_SETUP
+   echo -e "Error: Unable to target region [$IC_REGION]." >> $E2E_TEST_SETUP
    exit 1
 fi
-
-ibmcloud target -r "$IC_REGION"
 
 if [ -z "$IC_REGION" ]; then
   echo "ERROR: IC_REGION is not set"
@@ -982,10 +1036,18 @@ if [[ -z "$KS_HOST" ]]; then
 fi
 
 echo "KS endpoint : $KS_HOST"
-ibmcloud ks init --host "$KS_HOST"
+ibmcloud ks init --host "$KS_HOST"; rc=$?
+if [[ $rc -ne 0 ]]; then
+   echo -e "Error: Failed to initialize Container Service host [$KS_HOST]." >> $E2E_TEST_SETUP
+   exit 1
+fi
 
 if [[ $IC_PROVIDER == "vpc-gen2" ]] ; then
-   ibmcloud is target --gen 2
+   ibmcloud is target --gen 2; rc=$?
+   if [[ $rc -ne 0 ]]; then
+      echo -e "Error: VPC infrastructure plugin could not target region [$IC_REGION]. Verify the Jenkins IBM Cloud CLI / VPC plugin supports this region." >> $E2E_TEST_SETUP
+      exit 1
+   fi
 fi
 
 
@@ -1084,6 +1146,20 @@ if [[ "$e2e_create_new_cluster" == "true" ]]; then
     var_secd="ZONE_${IC_PROVIDER//-/_}_${SECOND_ZONE_ID}"
     PRIMARY_ZONE=${!var_prim}
     SECOND_ZONE=${!var_secd}
+
+    if [[ "$E2ETEST_MZ" == "true" ]]; then
+        resolved_flavor=$(resolve_worker_node_flavor "$WORKER_NODE_FLAVOR" "$PRIMARY_ZONE" "$SECOND_ZONE"); rc=$?
+    else
+        resolved_flavor=$(resolve_worker_node_flavor "$WORKER_NODE_FLAVOR" "$PRIMARY_ZONE"); rc=$?
+    fi
+    if [[ $rc -ne 0 ]]; then
+        echo -e "Error: Unable to resolve worker flavor for [$PRIMARY_ZONE${SECOND_ZONE:+,$SECOND_ZONE}]!!!" >> $E2E_TEST_SETUP
+        exit 1
+    fi
+    if [[ "$resolved_flavor" != "$WORKER_NODE_FLAVOR" ]]; then
+        echo "Info: Using worker flavor [$resolved_flavor] instead of [$WORKER_NODE_FLAVOR]"
+    fi
+    WORKER_NODE_FLAVOR="$resolved_flavor"
 
     PRIMARY_PUB_VLAN=""
     PRIMARY_PRIV_VLAN=""

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -106,6 +106,34 @@ function updateCertPathInKubeConfig {
     echo "Info: Updated cert paths in KUBECONFIG..."
 }
 
+function normalize_addon_version_for_platform {
+    local requested_version="$1"
+    local version_no_prefix
+    local version_core
+    local major_minor
+
+    if [[ -z "$requested_version" || "$requested_version" == "default" ]]; then
+        echo "$requested_version"
+        return 0
+    fi
+
+    version_no_prefix=$(echo "$requested_version" | sed -E 's/^v//')
+    version_core=$(echo "$version_no_prefix" | sed -E 's/(_iks|_ocp)$//')
+    major_minor=$(echo "$version_core" | awk -F'.' '{print $1"."$2}')
+
+    # 5.1 uses platform-specific addon suffixes, while 5.2 and later do not.
+    if [[ "$major_minor" == "5.1" ]]; then
+        if [[ "$K8S_PLATFORM" == "openshift" ]]; then
+            echo "${version_core}_ocp"
+        else
+            echo "${version_core}_iks"
+        fi
+        return 0
+    fi
+
+    echo "$version_core"
+}
+
 function create_vlan_cls {
 	local e2e_env="$1"
 	local prim_zone="$2"
@@ -1160,21 +1188,15 @@ exportKubeConfig $cluster_name; rc=$?
 # From Jenkins there is option to mention addon version. 
 # So if value is not "default", disable and enable user specified version
 if [[ $e2e_addon_version != "default"  ]]; then
-        # For 5.1.x, ensure correct platform suffix (_iks for kubernetes, _ocp for openshift)
-        if [[ "$e2e_addon_version" == *"_iks"* || "$e2e_addon_version" == *"_ocp"* ]]; then
-            if [[ "$K8S_PLATFORM" == "openshift" ]]; then
-                e2e_addon_version=$(echo "$e2e_addon_version" | sed 's/_iks$/_ocp/')
-            else
-                e2e_addon_version=$(echo "$e2e_addon_version" | sed 's/_ocp$/_iks/')
-            fi
-        fi
-        echo "Info: Installing addon $e2e_addon_version"
-        ibmcloud ks cluster addon disable vpc-block-csi-driver -f --cluster $cluster_name
-        sleep 900
-        ibmcloud ks cluster addon enable vpc-block-csi-driver --cluster $cluster_name --version $e2e_addon_version
-        sleep 180
+    e2e_addon_version=$(normalize_addon_version_for_platform "$e2e_addon_version")
+    echo "Info: Installing addon $e2e_addon_version"
+    ibmcloud ks cluster addon disable vpc-block-csi-driver -f --cluster $cluster_name
+    sleep 900
+    ibmcloud ks cluster addon enable vpc-block-csi-driver --cluster $cluster_name --version $e2e_addon_version
+    sleep 180
 	check_addon_pod_status ibm-vpc-block-csi-controller
 fi
+
 set -x 
 if [[ $rc -ne 0 ]]; then echo -e "Error: Cluster ($cluster_name) export kube config failed!!!" >> $E2E_TEST_SETUP; exit 1; fi
 if [[ -n "$e2e_var_exports" ]]; then

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -815,10 +815,13 @@ fi
 if [[ "$e2e_k8s_platform" == "k8s" ]]; then  K8S_PLATFORM="kubernetes"; else K8S_PLATFORM="openshift"; fi
 
 # Set APIs
-if [[ "$e2e_env" = "stage" || "$e2e_env" = "stage-us-south" ]]; then
+if [[ "$e2e_env" = "stage" ]]; then
     E2ETEST_IC_API_EP="https://test.cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://containers.test.cloud.ibm.com"
     E2ETEST_IC_RES_GRP="Default"
+elif [[ "$e2e_env" = "stage-us-south" ]]; then
+    E2ETEST_IC_API_EP="https://test.cloud.ibm.com"
+    [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
 else
     E2ETEST_IC_API_EP="https://cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://containers.cloud.ibm.com"
@@ -856,15 +859,25 @@ if [[ $rc -ne 0 ]]; then
    echo -e "Error: Invalid option \"-r $e2e_ic_region\"!!!" >> $E2E_TEST_SETUP
    exit 1
 fi
-#assign region if env == stage-us-south
+# #assign region if env == stage-us-south
+# if [[ "$e2e_env" == "stage-us-south" ]]; then
+#     IC_REGION="us-south"                 # REAL REGION
+#     ZONE_PREFIX="us-south-ngdc-test"     # ZONE PREFIX
+#     WORKER_NODE_FLAVOR="bx3d.4x20"
+# else
+#     IC_REGION="$e2e_ic_region"
+#     ZONE_PREFIX="$IC_REGION"
+# fi
+
+# Resolve final region
 if [[ "$e2e_env" == "stage-us-south" ]]; then
-    IC_REGION="us-south"                 # REAL REGION
-    ZONE_PREFIX="us-south-ngdc-test"     # ZONE PREFIX
+    IC_REGION="us-south-ngdc-test"
+    # Set default test flavor only if not explicitly set
     WORKER_NODE_FLAVOR="bx3d.4x20"
 else
     IC_REGION="$e2e_ic_region"
-    ZONE_PREFIX="$IC_REGION"
 fi
+
 # Validate the final region
 ibmcloud regions | grep -w "$IC_REGION" > /dev/null || {
    echo -e "Error: Invalid region \"$IC_REGION\"!!!" >> $E2E_TEST_SETUP

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -815,12 +815,9 @@ fi
 if [[ "$e2e_k8s_platform" == "k8s" ]]; then  K8S_PLATFORM="kubernetes"; else K8S_PLATFORM="openshift"; fi
 
 # Set APIs
-if [[ "$e2e_env" = "stage" ]]; then
+if [[ "$e2e_env" = "stage" || "$e2e_env" = "stage-us-south" ]]; then
     E2ETEST_IC_API_EP="https://test.cloud.ibm.com"
     [[ -z "$E2ETEST_CS_API_EP" ]] && E2ETEST_CS_API_EP="https://containers.test.cloud.ibm.com"
-    E2ETEST_IC_RES_GRP="Default"
-elif [[ "$e2e_env" = "stage-us-south" ]]; then
-    E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
     E2ETEST_IC_RES_GRP="Default"
 else
     E2ETEST_IC_API_EP="https://cloud.ibm.com"
@@ -838,6 +835,7 @@ if [[ "$PRIMARY_ZONE_ID" == "$SECOND_ZONE_ID" ]]; then
 fi
 
 # Login to IBM Cloud
+echo "==========LOGGING INTO IBMCLOUD=============="
 set +x
 if [[ -z "$E2ETEST_API_KEY" ]]; then
     if [[ "$e2e_env" = "stage" || "$e2e_env" = "stage-us-south" ]]; then
@@ -863,8 +861,15 @@ fi
 IC_REGION="$e2e_ic_region"
 ibmcloud target -r "$IC_REGION"
 
-if [[ -n "$E2ETEST_CS_API_EP" ]]; then
-   ibmcloud ks init --host $E2ETEST_CS_API_EP
+echo "----- ic ks init -----"
+if [[ "$e2e_env" = "stage" ]]; then
+    E2ETEST_CS_API_EP="https://test.cloud.ibm.com"
+    E2ETEST_IC_RES_GRP="Default"
+    ibmcloud ks init --host $E2ETEST_CS_API_EP
+elif [[ "$e2e_env" = "stage-us-south" ]]; then
+    E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
+    E2ETEST_IC_RES_GRP="Default"
+    ibmcloud ks init --host $E2ETEST_CS_API_EP
 elif [[ "$IC_REGION" == "ca-mon" ]]; then
    ibmcloud ks init --host https://ca-mon.containers.cloud.ibm.com
    WORKER_NODE_FLAVOR=${E2ETEST_NODE_FLAVOR:-bx3d.4x20}

--- a/tests/e2e/iks-cluster
+++ b/tests/e2e/iks-cluster
@@ -792,7 +792,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [[ -z "$IC_API_KEY_PROD" && -z "$IC_API_KEY_STAG"  ]]; then echo -e "Error: E2ETEST_API_KEY not set!!!" >> $E2E_TEST_SETUP; exit 1;  fi
 
 E2ETEST_MZ="$e2e_mz"
-if [[ "$e2e_env" != "prod" && "$e2e_env" != "stage" &&  "$e2e_env" != "stage-us-south" ]]; then
+if [[ "$e2e_env" != "prod" && "$e2e_env" != "stage" ]]; then
 	echo -e "Error: Invalid option \"-e $e2e_env\"!!!" >> $E2E_TEST_SETUP
 	exit 1
 fi
@@ -857,9 +857,9 @@ if [[ $rc -ne 0 ]]; then
    exit 1
 fi
 # assign region if env == stage-us-south
-if [[ "$e2e_env" == "stage-us-south" ]]; then
-    e2e_ic_region="us-south-ngdc-test"
-fi
+# if [[ "$e2e_env" == "stage-us-south" ]]; then
+#     e2e_ic_region="us-south-ngdc-test"
+# fi
 
 ibmcloud target -r "$IC_REGION"
 
@@ -868,10 +868,10 @@ if [[ "$e2e_env" = "stage" ]]; then
     E2ETEST_CS_API_EP="https://test.cloud.ibm.com"
     E2ETEST_IC_RES_GRP="Default"
     ibmcloud ks init --host $E2ETEST_CS_API_EP
-elif [[ "$e2e_env" = "stage-us-south" ]]; then
-    E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
-    E2ETEST_IC_RES_GRP="Default"
-    ibmcloud ks init --host $E2ETEST_CS_API_EP
+# elif [[ "$e2e_env" = "stage-us-south" ]]; then
+#     E2ETEST_CS_API_EP="https://stage-us-south.containers.test.cloud.ibm.com"
+#     E2ETEST_IC_RES_GRP="Default"
+#     ibmcloud ks init --host $E2ETEST_CS_API_EP
 elif [[ "$IC_REGION" == "ca-mon" ]]; then
    ibmcloud ks init --host https://ca-mon.containers.cloud.ibm.com
    WORKER_NODE_FLAVOR=${E2ETEST_NODE_FLAVOR:-bx3d.4x20}

--- a/tests/e2e/pvc_tests.go
+++ b/tests/e2e/pvc_tests.go
@@ -723,6 +723,12 @@ var _ = Describe("[ics-e2e] [with-sdp-profile] Provisioning PVC with SDP profile
 			fmt.Println("Version format is invalid")
 		}
 
+		// SDP profile test skip in ngdc-test regions
+		zone := os.Getenv("E2E_ZONE")
+		if strings.Contains(zone, "ngdc-test") {
+			condition = false
+		}
+
 		snapshotrcs, err = restClient(testsuites.SnapshotAPIGroup, testsuites.APIVersionv1)
 		if err != nil {
 			Fail(fmt.Sprintf("could not get rest clientset: %v", err))
@@ -732,7 +738,7 @@ var _ = Describe("[ics-e2e] [with-sdp-profile] Provisioning PVC with SDP profile
 	// sc and pvc are according to doc, positive scenerio,  pvc creation will be successful
 	It("with custom sc(iops=3000, throughput=1000, pvc size=1Gi): should create a pvc & pv, pod resources, write and read to volume", func() {
 		if condition == false {
-			Skip("Skipping because addon version is 5.1 and acadia profile is not supported for this version")
+			Skip("Skipping SDP test - SDP profile is not supported (addon 5.1 or ngdc-test region)")
 		}
 
 		// Create SDP profile of ext4 fsType sc

--- a/tests/e2e/pvc_tests.go
+++ b/tests/e2e/pvc_tests.go
@@ -708,9 +708,11 @@ var _ = Describe("[ics-e2e] [with-sdp-profile] Provisioning PVC with SDP profile
 			version = deployment.ObjectMeta.Annotations["version"]
 			fmt.Println("Addon version:", version)
 		}
-		//once 5.1 deprecates we can remove version check
-		//saving x.y version
-		parts := strings.Split(version, ".")
+
+		// once 5.1 deprecates we can remove version check
+		// normalize v-prefixed versions, then save x.y
+		normalizedVersion := strings.TrimPrefix(version, "v")
+		parts := strings.Split(normalizedVersion, ".")
 		if len(parts) >= 2 {
 			majorMinor := fmt.Sprintf("%s.%s", parts[0], parts[1])
 			fmt.Println("Major.Minor:", majorMinor)

--- a/tests/e2e/testsuites/baseutils.go
+++ b/tests/e2e/testsuites/baseutils.go
@@ -544,7 +544,7 @@ func (t *TestPersistentVolumeClaim) WaitForPending() v1.PersistentVolumeClaim {
 	var err error
 
 	By(fmt.Sprintf("waiting for PVC to be in phase %q", v1.ClaimPending))
-	time.Sleep(5 * time.Minute)
+	time.Sleep(10 * time.Minute)
 	err = k8sDevPV.WaitForPersistentVolumeClaimPhase(context.TODO(), v1.ClaimPending, t.client, t.namespace.Name, t.persistentVolumeClaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
 	framework.ExpectNoError(err)
 

--- a/tests/e2e/testsuites/baseutils.go
+++ b/tests/e2e/testsuites/baseutils.go
@@ -613,6 +613,31 @@ type TestDeployment struct {
 	podName    string
 }
 
+func podSecurityContext() *v1.PodSecurityContext {
+	return &v1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+func containerSecurityContext() *v1.SecurityContext {
+	return &v1.SecurityContext{
+		RunAsUser:                ptr.To(int64(1000)),
+		RunAsGroup:               ptr.To(int64(1000)),
+		RunAsNonRoot:             ptr.To(true),
+		ReadOnlyRootFilesystem:   ptr.To(false),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"ALL"},
+		},
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
 func NewTestDeployment(c clientset.Interface, ns *v1.Namespace, command string, pvc *v1.PersistentVolumeClaim, volumeName, mountPath string, readOnly bool) *TestDeployment {
 	generateName := "ics-e2e-tester-"
 	selectorValue := fmt.Sprintf("%s%d", generateName, rand.Int())
@@ -634,6 +659,7 @@ func NewTestDeployment(c clientset.Interface, ns *v1.Namespace, command string, 
 						Labels: map[string]string{"app": selectorValue},
 					},
 					Spec: v1.PodSpec{
+						SecurityContext: podSecurityContext(),
 						Containers: []v1.Container{
 							{
 								Name:    "ics-e2e-tester",
@@ -647,12 +673,7 @@ func NewTestDeployment(c clientset.Interface, ns *v1.Namespace, command string, 
 										ReadOnly:  readOnly,
 									},
 								},
-								SecurityContext: &v1.SecurityContext{
-									RunAsUser:                ptr.To(int64(0)),
-									RunAsGroup:               ptr.To(int64(0)),
-									ReadOnlyRootFilesystem:   ptr.To(false),
-									AllowPrivilegeEscalation: ptr.To(false),
-								},
+								SecurityContext: containerSecurityContext(),
 							},
 						},
 						RestartPolicy: v1.RestartPolicyAlways,

--- a/tests/e2e/testsuites/baseutils.go
+++ b/tests/e2e/testsuites/baseutils.go
@@ -616,6 +616,9 @@ type TestDeployment struct {
 func podSecurityContext() *v1.PodSecurityContext {
 	return &v1.PodSecurityContext{
 		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To(int64(1000)),
+		RunAsGroup:   ptr.To(int64(1000)),
+		FSGroup:      ptr.To(int64(1000)),
 		SeccompProfile: &v1.SeccompProfile{
 			Type: v1.SeccompProfileTypeRuntimeDefault,
 		},
@@ -624,8 +627,6 @@ func podSecurityContext() *v1.PodSecurityContext {
 
 func containerSecurityContext() *v1.SecurityContext {
 	return &v1.SecurityContext{
-		RunAsUser:                ptr.To(int64(1000)),
-		RunAsGroup:               ptr.To(int64(1000)),
 		RunAsNonRoot:             ptr.To(true),
 		ReadOnlyRootFilesystem:   ptr.To(false),
 		AllowPrivilegeEscalation: ptr.To(false),
@@ -847,15 +848,17 @@ func NewTestPodWithName(c clientset.Interface, ns *v1.Namespace, name, command s
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
-						Name:         "ics-e2e-tester",
-						Image:        icrImage,
-						Command:      []string{"/bin/sh"},
-						Args:         []string{"-c", command},
-						VolumeMounts: make([]v1.VolumeMount, 0),
+						Name:            "ics-e2e-tester",
+						Image:           icrImage,
+						Command:         []string{"/bin/sh"},
+						Args:            []string{"-c", command},
+						VolumeMounts:    make([]v1.VolumeMount, 0),
+						SecurityContext: containerSecurityContext(),
 					},
 				},
-				RestartPolicy: v1.RestartPolicyNever,
-				Volumes:       make([]v1.Volume, 0),
+				RestartPolicy:   v1.RestartPolicyNever,
+				Volumes:         make([]v1.Volume, 0),
+				SecurityContext: podSecurityContext(),
 			},
 		},
 	}

--- a/tests/e2e/testsuites/baseutils.go
+++ b/tests/e2e/testsuites/baseutils.go
@@ -98,6 +98,32 @@ func NewHeadlessService(c clientset.Interface, name, namespace, labelSelctors st
 	}
 }
 
+func podSecurityContext() *v1.PodSecurityContext {
+	return &v1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To(int64(1000)),
+		RunAsGroup:   ptr.To(int64(1000)),
+		FSGroup:      ptr.To(int64(1000)),
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+func containerSecurityContext() *v1.SecurityContext {
+	return &v1.SecurityContext{
+		RunAsNonRoot:             ptr.To(true),
+		ReadOnlyRootFilesystem:   ptr.To(false),
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{"ALL"},
+		},
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
 func (t *TestPersistentVolumeClaim) NewTestStatefulset(c clientset.Interface, ns *v1.Namespace, servicename, command, storageClassName, volumeName, mountPath string, labels map[string]string, replicaCount int32) *TestStatefulsets {
 	pvcTemplate := generatePVC(volumeName, t.namespace.Name, storageClassName, t.claimSize, t.accessMode, t.volumeMode, t.dataSource)
 	generateName := "ics-e2e-tester-"
@@ -122,6 +148,7 @@ func (t *TestPersistentVolumeClaim) NewTestStatefulset(c clientset.Interface, ns
 						Labels: labels,
 					},
 					Spec: v1.PodSpec{
+						SecurityContext: podSecurityContext(),
 						Containers: []v1.Container{
 							{
 								Name:    "statefulset",
@@ -140,6 +167,7 @@ func (t *TestPersistentVolumeClaim) NewTestStatefulset(c clientset.Interface, ns
 										MountPath: mountPath,
 									},
 								},
+								SecurityContext: containerSecurityContext(),
 							},
 						},
 					},
@@ -613,32 +641,6 @@ type TestDeployment struct {
 	podName    string
 }
 
-func podSecurityContext() *v1.PodSecurityContext {
-	return &v1.PodSecurityContext{
-		RunAsNonRoot: ptr.To(true),
-		RunAsUser:    ptr.To(int64(1000)),
-		RunAsGroup:   ptr.To(int64(1000)),
-		FSGroup:      ptr.To(int64(1000)),
-		SeccompProfile: &v1.SeccompProfile{
-			Type: v1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-}
-
-func containerSecurityContext() *v1.SecurityContext {
-	return &v1.SecurityContext{
-		RunAsNonRoot:             ptr.To(true),
-		ReadOnlyRootFilesystem:   ptr.To(false),
-		AllowPrivilegeEscalation: ptr.To(false),
-		Capabilities: &v1.Capabilities{
-			Drop: []v1.Capability{"ALL"},
-		},
-		SeccompProfile: &v1.SeccompProfile{
-			Type: v1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-}
-
 func NewTestDeployment(c clientset.Interface, ns *v1.Namespace, command string, pvc *v1.PersistentVolumeClaim, volumeName, mountPath string, readOnly bool) *TestDeployment {
 	generateName := "ics-e2e-tester-"
 	selectorValue := fmt.Sprintf("%s%d", generateName, rand.Int())
@@ -878,19 +880,17 @@ func NewTestPod(c clientset.Interface, ns *v1.Namespace, command string) *TestPo
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
-						Name:         "ics-e2e-tester",
-						Image:        icrImage,
-						Command:      []string{"/bin/sh"},
-						Args:         []string{"-c", command},
-						VolumeMounts: make([]v1.VolumeMount, 0),
-						SecurityContext: &v1.SecurityContext{
-							RunAsUser:  ptr.To(int64(0)),
-							RunAsGroup: ptr.To(int64(0)),
-						},
+						Name:            "ics-e2e-tester",
+						Image:           icrImage,
+						Command:         []string{"/bin/sh"},
+						Args:            []string{"-c", command},
+						VolumeMounts:    make([]v1.VolumeMount, 0),
+						SecurityContext: containerSecurityContext(),
 					},
 				},
-				RestartPolicy: v1.RestartPolicyNever,
-				Volumes:       make([]v1.Volume, 0),
+				RestartPolicy:   v1.RestartPolicyNever,
+				Volumes:         make([]v1.Volume, 0),
+				SecurityContext: podSecurityContext(),
 			},
 		},
 	}

--- a/tests/e2e/testsuites/baseutils.go
+++ b/tests/e2e/testsuites/baseutils.go
@@ -530,6 +530,27 @@ func (t *TestPersistentVolumeClaim) WaitForBound() v1.PersistentVolumeClaim {
 
 	By(fmt.Sprintf("waiting for PVC to be in phase %q", v1.ClaimBound))
 	err = k8sDevPV.WaitForPersistentVolumeClaimPhase(context.TODO(), v1.ClaimBound, t.client, t.namespace.Name, t.persistentVolumeClaim.Name, framework.Poll, framework.ClaimProvisionTimeout)
+	if err != nil {
+		framework.Logf("PVC [%s/%s] failed to reach phase %q within %v: %v", t.namespace.Name, t.persistentVolumeClaim.Name, v1.ClaimBound, framework.ClaimProvisionTimeout, err)
+		pvc, pvcErr := t.client.CoreV1().PersistentVolumeClaims(t.namespace.Name).Get(context.Background(), t.persistentVolumeClaim.Name, metav1.GetOptions{})
+		if pvcErr != nil {
+			framework.Logf("unable to fetch PVC [%s/%s] after timeout: %v", t.namespace.Name, t.persistentVolumeClaim.Name, pvcErr)
+		} else {
+			framework.Logf("PVC [%s/%s] current status: phase=%q, volumeName=%q, conditions=%v", t.namespace.Name, t.persistentVolumeClaim.Name, pvc.Status.Phase, pvc.Spec.VolumeName, pvc.Status.Conditions)
+		}
+
+		eventSelector := fmt.Sprintf("involvedObject.kind=PersistentVolumeClaim,involvedObject.name=%s", t.persistentVolumeClaim.Name)
+		events, eventErr := t.client.CoreV1().Events(t.namespace.Name).List(context.Background(), metav1.ListOptions{FieldSelector: eventSelector})
+		if eventErr != nil {
+			framework.Logf("unable to list PVC events for [%s/%s]: %v", t.namespace.Name, t.persistentVolumeClaim.Name, eventErr)
+		} else if len(events.Items) == 0 {
+			framework.Logf("no events found for PVC [%s/%s]", t.namespace.Name, t.persistentVolumeClaim.Name)
+		} else {
+			for _, e := range events.Items {
+				framework.Logf("PVC event [%s/%s]: type=%s reason=%s message=%q count=%d lastTimestamp=%s", t.namespace.Name, t.persistentVolumeClaim.Name, e.Type, e.Reason, e.Message, e.Count, e.LastTimestamp.String())
+			}
+		}
+	}
 	framework.ExpectNoError(err)
 
 	By("checking the PVC")

--- a/tests/e2e/testsuites/baseutils.go
+++ b/tests/e2e/testsuites/baseutils.go
@@ -98,16 +98,36 @@ func NewHeadlessService(c clientset.Interface, name, namespace, labelSelctors st
 	}
 }
 
-func podSecurityContext() *v1.PodSecurityContext {
-	return &v1.PodSecurityContext{
+func isOpenShiftCluster(c clientset.Interface) bool {
+	platform := strings.ToLower(strings.TrimSpace(os.Getenv("PLATFORM")))
+	if platform == "ocp" {
+		return true
+	}
+
+	if c == nil {
+		return false
+	}
+
+	_, err := c.CoreV1().Namespaces().Get(context.Background(), "openshift-config", metav1.GetOptions{})
+	return err == nil
+}
+
+func podSecurityContext(c clientset.Interface) *v1.PodSecurityContext {
+	securityContext := &v1.PodSecurityContext{
 		RunAsNonRoot: ptr.To(true),
-		RunAsUser:    ptr.To(int64(1000)),
-		RunAsGroup:   ptr.To(int64(1000)),
-		FSGroup:      ptr.To(int64(1000)),
 		SeccompProfile: &v1.SeccompProfile{
 			Type: v1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
+
+	// let OpenShift SCC assign UID/GID/FSGroup for OCP platform
+	if !isOpenShiftCluster(c) {
+		securityContext.RunAsUser = ptr.To(int64(1000))
+		securityContext.RunAsGroup = ptr.To(int64(1000))
+		securityContext.FSGroup = ptr.To(int64(1000))
+	}
+
+	return securityContext
 }
 
 func containerSecurityContext() *v1.SecurityContext {
@@ -148,7 +168,7 @@ func (t *TestPersistentVolumeClaim) NewTestStatefulset(c clientset.Interface, ns
 						Labels: labels,
 					},
 					Spec: v1.PodSpec{
-						SecurityContext: podSecurityContext(),
+						SecurityContext: podSecurityContext(c),
 						Containers: []v1.Container{
 							{
 								Name:    "statefulset",
@@ -175,7 +195,6 @@ func (t *TestPersistentVolumeClaim) NewTestStatefulset(c clientset.Interface, ns
 			},
 		},
 	}
-
 }
 
 func (h *TestHeadlessService) Create() v1.Service {
@@ -683,7 +702,7 @@ func NewTestDeployment(c clientset.Interface, ns *v1.Namespace, command string, 
 						Labels: map[string]string{"app": selectorValue},
 					},
 					Spec: v1.PodSpec{
-						SecurityContext: podSecurityContext(),
+						SecurityContext: podSecurityContext(c),
 						Containers: []v1.Container{
 							{
 								Name:    "ics-e2e-tester",
@@ -881,7 +900,7 @@ func NewTestPodWithName(c clientset.Interface, ns *v1.Namespace, name, command s
 				},
 				RestartPolicy:   v1.RestartPolicyNever,
 				Volumes:         make([]v1.Volume, 0),
-				SecurityContext: podSecurityContext(),
+				SecurityContext: podSecurityContext(c),
 			},
 		},
 	}
@@ -911,7 +930,7 @@ func NewTestPod(c clientset.Interface, ns *v1.Namespace, command string) *TestPo
 				},
 				RestartPolicy:   v1.RestartPolicyNever,
 				Volumes:         make([]v1.Volume, 0),
-				SecurityContext: podSecurityContext(),
+				SecurityContext: podSecurityContext(c),
 			},
 		},
 	}

--- a/tests/e2e/volume_attach.go
+++ b/tests/e2e/volume_attach.go
@@ -902,6 +902,10 @@ func CreateStorageClass(scName, profile, fsType, iops, throughput string, cs cli
 				baseParams["zone"] = zone
 			}
 
+			if _, hasProfile := baseParams["profile"]; !hasProfile && profile != "" {
+				baseParams["profile"] = profile
+			}
+
 			storageClass = &storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,

--- a/tests/e2e/volume_attach.go
+++ b/tests/e2e/volume_attach.go
@@ -830,6 +830,27 @@ func CreatePVC(pvcName string, namespace string, cs clientset.Interface) {
 	}
 }
 
+func cloneStringMap(values map[string]string) map[string]string {
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func tierBaseStorageClassName(profile string) string {
+	switch profile {
+	case "5iops-tier":
+		return "ibmc-vpc-block-5iops-tier"
+	case "general-purpose":
+		return "ibmc-vpc-block-general-purpose"
+	case "10iops-tier":
+		return "ibmc-vpc-block-10iops-tier"
+	default:
+		return ""
+	}
+}
+
 // CreateStorageClass creates a storage class with the specified parameters
 // Parameters:
 //   - scName: Name of the storage class
@@ -839,7 +860,7 @@ func CreatePVC(pvcName string, namespace string, cs clientset.Interface) {
 //   - throughput: Throughput in MB/s (only used for "sdp" profile, empty string otherwise)
 //   - cs: Kubernetes clientset
 func CreateStorageClass(scName, profile, fsType, iops, throughput string, cs clientset.Interface) {
-	var zone = os.Getenv("E2E_ZONE")
+	zone := strings.TrimSpace(os.Getenv("E2E_ZONE"))
 	flag := true
 
 	params := map[string]string{
@@ -866,6 +887,37 @@ func CreateStorageClass(scName, profile, fsType, iops, throughput string, cs cli
 		Provisioner:          "vpc.block.csi.ibm.io",
 		Parameters:           params,
 		AllowVolumeExpansion: &flag,
+	}
+
+	// For tier profiles, use the cluster-installed StorageClass to preserve version-specific parameters needed by the addon, then only override fsType/zone.
+	baseSCName := tierBaseStorageClassName(profile)
+	if baseSCName != "" {
+		baseSC, baseErr := cs.StorageV1().StorageClasses().Get(context.Background(), baseSCName, metav1.GetOptions{})
+		if baseErr != nil {
+			log.Printf("Failed to fetch base StorageClass %q for profile %q. Falling back to static params: %v", baseSCName, profile, baseErr)
+		} else {
+			baseParams := cloneStringMap(baseSC.Parameters)
+			baseParams["csi.storage.k8s.io/fstype"] = fsType
+			if zone != "" {
+				baseParams["zone"] = zone
+			}
+
+			storageClass = &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: scName,
+				},
+				Provisioner:          baseSC.Provisioner,
+				Parameters:           baseParams,
+				ReclaimPolicy:        baseSC.ReclaimPolicy,
+				MountOptions:         append([]string(nil), baseSC.MountOptions...),
+				AllowVolumeExpansion: baseSC.AllowVolumeExpansion,
+				VolumeBindingMode:    baseSC.VolumeBindingMode,
+				AllowedTopologies:    append([]corev1.TopologySelectorTerm(nil), baseSC.AllowedTopologies...),
+			}
+			if storageClass.AllowVolumeExpansion == nil {
+				storageClass.AllowVolumeExpansion = &flag
+			}
+		}
 	}
 
 	_, err := cs.StorageV1().StorageClasses().Create(context.Background(), storageClass, metav1.CreateOptions{})

--- a/tests/e2e/xfs_tests.go
+++ b/tests/e2e/xfs_tests.go
@@ -18,7 +18,10 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"os"
+	"strings"
 
 	"github.com/IBM/ibm-csi-common/tests/e2e/testsuites"
 	. "github.com/onsi/ginkgo/v2"
@@ -37,12 +40,44 @@ var _ = Describe("[ics-e2e] [xfs] [sc] Dynamic Provisioning for XFS Filesystem",
 		err      error
 	)
 
+	condition := true // addon version >= 5.2 check for SDP tests
 	testResultFile := os.Getenv("E2E_TEST_RESULT")
 	fw = framework.NewDefaultFramework("ics-e2e-xfs")
 
 	BeforeEach(func() {
 		cs = fw.ClientSet
 		ns = fw.Namespace
+
+		// Check addon version for SDP test gating
+		version := ""
+		deployment, err := cs.AppsV1().Deployments("kube-system").Get(context.TODO(), "ibm-vpc-block-csi-controller", metav1.GetOptions{})
+		if err != nil {
+			log.Printf("Error getting Deployment: %v", err)
+			sts, err := cs.AppsV1().StatefulSets("kube-system").Get(context.TODO(), "ibm-vpc-block-csi-controller", metav1.GetOptions{})
+			if err != nil {
+				log.Fatalln("Error getting Sts and Deployment")
+			}
+			log.Println("STS Found")
+			version = sts.ObjectMeta.Annotations["version"]
+			fmt.Println("Addon version:", version)
+		} else {
+			log.Println("Deployment Found")
+			version = deployment.ObjectMeta.Annotations["version"]
+			fmt.Println("Addon version:", version)
+		}
+
+		// once 5.1 deprecates we can remove version check
+		normalizedVersion := strings.TrimPrefix(version, "v")
+		parts := strings.Split(normalizedVersion, ".")
+		if len(parts) >= 2 {
+			majorMinor := fmt.Sprintf("%s.%s", parts[0], parts[1])
+			fmt.Println("Major.Minor:", majorMinor)
+			if majorMinor == "5.1" {
+				condition = false
+			}
+		} else {
+			fmt.Println("Version format is invalid")
+		}
 	})
 
 	// Test 1: XFS with Tier Profile - Pod
@@ -143,122 +178,140 @@ var _ = Describe("[ics-e2e] [xfs] [sc] Dynamic Provisioning for XFS Filesystem",
 	})
 
 	// Test 3: XFS with SDP Profile - Pod
-	// It("[xfs-sdp-pod] with XFS SDP profile: should create pvc & pv, pod resources", func() {
-	// 	CreateStorageClass("xfs-sdp-test-sc", "sdp", "xfs", "3000", "1000", cs)
-	// 	defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-test-sc", metav1.DeleteOptions{})
+	It("[xfs-sdp-pod] with XFS SDP profile: should create pvc & pv, pod resources", func() {
+		if condition == false {
+			Skip("Skipping XFS SDP test - addon version is 5.1 and SDP profile is not supported")
+		}
 
-	// 	// Create secret for SDP
-	// 	secretKey := os.Getenv("IC_API_KEY_STAG")
-	// 	if secretKey == "" {
-	// 		Skip("Skipping SDP test - IC_API_KEY_STAG not set")
-	// 	}
+		CreateStorageClass("xfs-sdp-test-sc", "sdp", "xfs", "3000", "1000", cs)
+		defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-test-sc", metav1.DeleteOptions{})
 
-	// 	secret := testsuites.NewSecret(cs, "xfs-sdp-test-pvc", ns.Name, "800", "e2e test",
-	// 		"false", secretKey, "vpc.block.csi.ibm.io")
-	// 	secret.Create()
-	// 	defer secret.Cleanup()
+		// Create secret for SDP
+		secretKey := os.Getenv("IC_API_KEY_STAG")
+		if secretKey == "" {
+			fp, fperr := os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if fperr == nil {
+				fp.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Test: SKIP\n")
+				fp.Close()
+			}
+			Skip("Skipping SDP test - IC_API_KEY_STAG not set")
+		}
 
-	// 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
-	// 	fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	// 	if err != nil {
-	// 		panic(err)
-	// 	}
-	// 	defer fpointer.Close()
+		secret := testsuites.NewSecret(cs, "xfs-sdp-test-pvc", ns.Name, "800", "e2e test",
+			"false", secretKey, "vpc.block.csi.ibm.io")
+		secret.Create()
+		defer secret.Cleanup()
 
-	// 	pods := []testsuites.PodDetails{
-	// 		{
-	// 			Cmd:      "xfs_info /mnt/test-1; echo 'xfs sdp test' > /mnt/test-1/data && while true; do sleep 2; done",
-	// 			CmdExits: false,
-	// 			Volumes: []testsuites.VolumeDetails{
-	// 				{
-	// 					PVCName:       "xfs-sdp-test-pvc",
-	// 					VolumeType:    "xfs-sdp-test-sc",
-	// 					FSType:        "xfs",
-	// 					ClaimSize:     "10Gi",
-	// 					ReclaimPolicy: &reclaimPolicy,
-	// 					MountOptions:  []string{"rw"},
-	// 					VolumeMount: testsuites.VolumeMountDetails{
-	// 						NameGenerate:      "test-volume-",
-	// 						MountPathGenerate: "/mnt/test-",
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	}
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+		defer fpointer.Close()
 
-	// 	test := testsuites.DynamicallyProvisionePodWithVolTest{
-	// 		Pods: pods,
-	// 		PodCheck: &testsuites.PodExecCheck{
-	// 			Cmd:              []string{"cat", "/mnt/test-1/data"},
-	// 			ExpectedString01: "xfs sdp test\n",
-	// 			ExpectedString02: "xfs sdp test\nxfs sdp test\n",
-	// 		},
-	// 	}
-	// 	test.Run(cs, ns)
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "xfs_info /mnt/test-1; echo 'xfs sdp test' > /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "xfs-sdp-test-pvc",
+						VolumeType:    "xfs-sdp-test-sc",
+						FSType:        "xfs",
+						ClaimSize:     "10Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
 
-	// 	if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Test: PASS\n"); err != nil {
-	// 		panic(err)
-	// 	}
-	// })
+		test := testsuites.DynamicallyProvisionePodWithVolTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "xfs sdp test\n",
+				ExpectedString02: "xfs sdp test\nxfs sdp test\n",
+			},
+		}
+		test.Run(cs, ns)
 
-	// // Test 4: XFS with SDP Profile - Resize
-	// It("[xfs-sdp-resize] with XFS SDP profile: should resize volume", func() {
-	// 	CreateStorageClass("xfs-sdp-resize-sc", "sdp", "xfs", "3000", "1000", cs)
-	// 	defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-resize-sc", metav1.DeleteOptions{})
+		if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Test: PASS\n"); err != nil {
+			panic(err)
+		}
+	})
 
-	// 	// Create secret for SDP
-	// 	secretKey := os.Getenv("IC_API_KEY_STAG")
-	// 	if secretKey == "" {
-	// 		Skip("Skipping SDP resize test - IC_API_KEY_STAG not set")
-	// 	}
+	// Test 4: XFS with SDP Profile - Resize
+	It("[xfs-sdp-resize] with XFS SDP profile: should resize volume", func() {
+		if condition == false {
+			Skip("Skipping XFS SDP resize test - addon version is 5.1 and SDP profile is not supported")
+		}
 
-	// 	secret := testsuites.NewSecret(cs, "xfs-sdp-resize-pvc", ns.Name, "800", "e2e test",
-	// 		"false", secretKey, "vpc.block.csi.ibm.io")
-	// 	secret.Create()
-	// 	defer secret.Cleanup()
+		CreateStorageClass("xfs-sdp-resize-sc", "sdp", "xfs", "3000", "1000", cs)
+		defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-resize-sc", metav1.DeleteOptions{})
 
-	// 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
-	// 	fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	// 	if err != nil {
-	// 		panic(err)
-	// 	}
-	// 	defer fpointer.Close()
+		// Create secret for SDP
+		secretKey := os.Getenv("IC_API_KEY_STAG")
+		if secretKey == "" {
+			fp, fperr := os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+			if fperr == nil {
+				fp.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Resize: SKIP\n")
+				fp.Close()
+			}
+			Skip("Skipping SDP resize test - IC_API_KEY_STAG not set")
+		}
 
-	// 	pods := []testsuites.PodDetails{
-	// 		{
-	// 			Cmd:      "echo 'xfs sdp resize test' >> /mnt/test-1/data && while true; do sleep 2; done",
-	// 			CmdExits: false,
-	// 			Volumes: []testsuites.VolumeDetails{
-	// 				{
-	// 					PVCName:       "xfs-sdp-resize-pvc",
-	// 					VolumeType:    "xfs-sdp-resize-sc",
-	// 					FSType:        "xfs",
-	// 					ClaimSize:     "10Gi",
-	// 					ReclaimPolicy: &reclaimPolicy,
-	// 					MountOptions:  []string{"rw"},
-	// 					VolumeMount: testsuites.VolumeMountDetails{
-	// 						NameGenerate:      "test-volume-",
-	// 						MountPathGenerate: "/mnt/test-",
-	// 					},
-	// 				},
-	// 			},
-	// 		},
-	// 	}
+		secret := testsuites.NewSecret(cs, "xfs-sdp-resize-pvc", ns.Name, "800", "e2e test",
+			"false", secretKey, "vpc.block.csi.ibm.io")
+		secret.Create()
+		defer secret.Cleanup()
 
-	// 	test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-	// 		Pods: pods,
-	// 		PodCheck: &testsuites.PodExecCheck{
-	// 			Cmd:              []string{"cat", "/mnt/test-1/data"},
-	// 			ExpectedString01: "xfs sdp resize test\n",
-	// 			ExpectedString02: "xfs sdp resize test\nxfs sdp resize test\n",
-	// 		},
-	// 		ExpandVolSizeG: 15,
-	// 		ExpandedSize:   14,
-	// 	}
-	// 	test.Run(cs, ns)
+		reclaimPolicy := v1.PersistentVolumeReclaimDelete
+		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+		defer fpointer.Close()
 
-	// 	if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Resize: PASS\n"); err != nil {
-	// 		panic(err)
-	// 	}
-	// })
+		pods := []testsuites.PodDetails{
+			{
+				Cmd:      "echo 'xfs sdp resize test' >> /mnt/test-1/data && while true; do sleep 2; done",
+				CmdExits: false,
+				Volumes: []testsuites.VolumeDetails{
+					{
+						PVCName:       "xfs-sdp-resize-pvc",
+						VolumeType:    "xfs-sdp-resize-sc",
+						FSType:        "xfs",
+						ClaimSize:     "10Gi",
+						ReclaimPolicy: &reclaimPolicy,
+						MountOptions:  []string{"rw"},
+						VolumeMount: testsuites.VolumeMountDetails{
+							NameGenerate:      "test-volume-",
+							MountPathGenerate: "/mnt/test-",
+						},
+					},
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+			Pods: pods,
+			PodCheck: &testsuites.PodExecCheck{
+				Cmd:              []string{"cat", "/mnt/test-1/data"},
+				ExpectedString01: "xfs sdp resize test\n",
+				ExpectedString02: "xfs sdp resize test\nxfs sdp resize test\n",
+			},
+			ExpandVolSizeG: 15,
+			ExpandedSize:   14,
+		}
+		test.Run(cs, ns)
+
+		if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Resize: PASS\n"); err != nil {
+			panic(err)
+		}
+	})
 })

--- a/tests/e2e/xfs_tests.go
+++ b/tests/e2e/xfs_tests.go
@@ -143,122 +143,122 @@ var _ = Describe("[ics-e2e] [xfs] [sc] Dynamic Provisioning for XFS Filesystem",
 	})
 
 	// Test 3: XFS with SDP Profile - Pod
-	It("[xfs-sdp-pod] with XFS SDP profile: should create pvc & pv, pod resources", func() {
-		CreateStorageClass("xfs-sdp-test-sc", "sdp", "xfs", "3000", "1000", cs)
-		defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-test-sc", metav1.DeleteOptions{})
+	// It("[xfs-sdp-pod] with XFS SDP profile: should create pvc & pv, pod resources", func() {
+	// 	CreateStorageClass("xfs-sdp-test-sc", "sdp", "xfs", "3000", "1000", cs)
+	// 	defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-test-sc", metav1.DeleteOptions{})
 
-		// Create secret for SDP
-		secretKey := os.Getenv("IC_API_KEY_STAG")
-		if secretKey == "" {
-			Skip("Skipping SDP test - IC_API_KEY_STAG not set")
-		}
+	// 	// Create secret for SDP
+	// 	secretKey := os.Getenv("IC_API_KEY_STAG")
+	// 	if secretKey == "" {
+	// 		Skip("Skipping SDP test - IC_API_KEY_STAG not set")
+	// 	}
 
-		secret := testsuites.NewSecret(cs, "xfs-sdp-test-pvc", ns.Name, "800", "e2e test",
-			"false", secretKey, "vpc.block.csi.ibm.io")
-		secret.Create()
-		defer secret.Cleanup()
+	// 	secret := testsuites.NewSecret(cs, "xfs-sdp-test-pvc", ns.Name, "800", "e2e test",
+	// 		"false", secretKey, "vpc.block.csi.ibm.io")
+	// 	secret.Create()
+	// 	defer secret.Cleanup()
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
+	// 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	// 	fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	defer fpointer.Close()
 
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "xfs_info /mnt/test-1; echo 'xfs sdp test' > /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "xfs-sdp-test-pvc",
-						VolumeType:    "xfs-sdp-test-sc",
-						FSType:        "xfs",
-						ClaimSize:     "10Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
+	// 	pods := []testsuites.PodDetails{
+	// 		{
+	// 			Cmd:      "xfs_info /mnt/test-1; echo 'xfs sdp test' > /mnt/test-1/data && while true; do sleep 2; done",
+	// 			CmdExits: false,
+	// 			Volumes: []testsuites.VolumeDetails{
+	// 				{
+	// 					PVCName:       "xfs-sdp-test-pvc",
+	// 					VolumeType:    "xfs-sdp-test-sc",
+	// 					FSType:        "xfs",
+	// 					ClaimSize:     "10Gi",
+	// 					ReclaimPolicy: &reclaimPolicy,
+	// 					MountOptions:  []string{"rw"},
+	// 					VolumeMount: testsuites.VolumeMountDetails{
+	// 						NameGenerate:      "test-volume-",
+	// 						MountPathGenerate: "/mnt/test-",
+	// 					},
+	// 				},
+	// 			},
+	// 		},
+	// 	}
 
-		test := testsuites.DynamicallyProvisionePodWithVolTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "xfs sdp test\n",
-				ExpectedString02: "xfs sdp test\nxfs sdp test\n",
-			},
-		}
-		test.Run(cs, ns)
+	// 	test := testsuites.DynamicallyProvisionePodWithVolTest{
+	// 		Pods: pods,
+	// 		PodCheck: &testsuites.PodExecCheck{
+	// 			Cmd:              []string{"cat", "/mnt/test-1/data"},
+	// 			ExpectedString01: "xfs sdp test\n",
+	// 			ExpectedString02: "xfs sdp test\nxfs sdp test\n",
+	// 		},
+	// 	}
+	// 	test.Run(cs, ns)
 
-		if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Test: PASS\n"); err != nil {
-			panic(err)
-		}
-	})
+	// 	if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Test: PASS\n"); err != nil {
+	// 		panic(err)
+	// 	}
+	// })
 
-	// Test 4: XFS with SDP Profile - Resize
-	It("[xfs-sdp-resize] with XFS SDP profile: should resize volume", func() {
-		CreateStorageClass("xfs-sdp-resize-sc", "sdp", "xfs", "3000", "1000", cs)
-		defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-resize-sc", metav1.DeleteOptions{})
+	// // Test 4: XFS with SDP Profile - Resize
+	// It("[xfs-sdp-resize] with XFS SDP profile: should resize volume", func() {
+	// 	CreateStorageClass("xfs-sdp-resize-sc", "sdp", "xfs", "3000", "1000", cs)
+	// 	defer cs.StorageV1().StorageClasses().Delete(context.Background(), "xfs-sdp-resize-sc", metav1.DeleteOptions{})
 
-		// Create secret for SDP
-		secretKey := os.Getenv("IC_API_KEY_STAG")
-		if secretKey == "" {
-			Skip("Skipping SDP resize test - IC_API_KEY_STAG not set")
-		}
+	// 	// Create secret for SDP
+	// 	secretKey := os.Getenv("IC_API_KEY_STAG")
+	// 	if secretKey == "" {
+	// 		Skip("Skipping SDP resize test - IC_API_KEY_STAG not set")
+	// 	}
 
-		secret := testsuites.NewSecret(cs, "xfs-sdp-resize-pvc", ns.Name, "800", "e2e test",
-			"false", secretKey, "vpc.block.csi.ibm.io")
-		secret.Create()
-		defer secret.Cleanup()
+	// 	secret := testsuites.NewSecret(cs, "xfs-sdp-resize-pvc", ns.Name, "800", "e2e test",
+	// 		"false", secretKey, "vpc.block.csi.ibm.io")
+	// 	secret.Create()
+	// 	defer secret.Cleanup()
 
-		reclaimPolicy := v1.PersistentVolumeReclaimDelete
-		fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			panic(err)
-		}
-		defer fpointer.Close()
+	// 	reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	// 	fpointer, err = os.OpenFile(testResultFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	defer fpointer.Close()
 
-		pods := []testsuites.PodDetails{
-			{
-				Cmd:      "echo 'xfs sdp resize test' >> /mnt/test-1/data && while true; do sleep 2; done",
-				CmdExits: false,
-				Volumes: []testsuites.VolumeDetails{
-					{
-						PVCName:       "xfs-sdp-resize-pvc",
-						VolumeType:    "xfs-sdp-resize-sc",
-						FSType:        "xfs",
-						ClaimSize:     "10Gi",
-						ReclaimPolicy: &reclaimPolicy,
-						MountOptions:  []string{"rw"},
-						VolumeMount: testsuites.VolumeMountDetails{
-							NameGenerate:      "test-volume-",
-							MountPathGenerate: "/mnt/test-",
-						},
-					},
-				},
-			},
-		}
+	// 	pods := []testsuites.PodDetails{
+	// 		{
+	// 			Cmd:      "echo 'xfs sdp resize test' >> /mnt/test-1/data && while true; do sleep 2; done",
+	// 			CmdExits: false,
+	// 			Volumes: []testsuites.VolumeDetails{
+	// 				{
+	// 					PVCName:       "xfs-sdp-resize-pvc",
+	// 					VolumeType:    "xfs-sdp-resize-sc",
+	// 					FSType:        "xfs",
+	// 					ClaimSize:     "10Gi",
+	// 					ReclaimPolicy: &reclaimPolicy,
+	// 					MountOptions:  []string{"rw"},
+	// 					VolumeMount: testsuites.VolumeMountDetails{
+	// 						NameGenerate:      "test-volume-",
+	// 						MountPathGenerate: "/mnt/test-",
+	// 					},
+	// 				},
+	// 			},
+	// 		},
+	// 	}
 
-		test := testsuites.DynamicallyProvisionedResizeVolumeTest{
-			Pods: pods,
-			PodCheck: &testsuites.PodExecCheck{
-				Cmd:              []string{"cat", "/mnt/test-1/data"},
-				ExpectedString01: "xfs sdp resize test\n",
-				ExpectedString02: "xfs sdp resize test\nxfs sdp resize test\n",
-			},
-			ExpandVolSizeG: 15,
-			ExpandedSize:   14,
-		}
-		test.Run(cs, ns)
+	// 	test := testsuites.DynamicallyProvisionedResizeVolumeTest{
+	// 		Pods: pods,
+	// 		PodCheck: &testsuites.PodExecCheck{
+	// 			Cmd:              []string{"cat", "/mnt/test-1/data"},
+	// 			ExpectedString01: "xfs sdp resize test\n",
+	// 			ExpectedString02: "xfs sdp resize test\nxfs sdp resize test\n",
+	// 		},
+	// 		ExpandVolSizeG: 15,
+	// 		ExpandedSize:   14,
+	// 	}
+	// 	test.Run(cs, ns)
 
-		if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Resize: PASS\n"); err != nil {
-			panic(err)
-		}
-	})
+	// 	if _, err = fpointer.WriteString("VPC-BLK-CSI-TEST: XFS SDP Profile Resize: PASS\n"); err != nil {
+	// 		panic(err)
+	// 	}
+	// })
 })

--- a/tests/e2e/xfs_tests.go
+++ b/tests/e2e/xfs_tests.go
@@ -78,6 +78,12 @@ var _ = Describe("[ics-e2e] [xfs] [sc] Dynamic Provisioning for XFS Filesystem",
 		} else {
 			fmt.Println("Version format is invalid")
 		}
+
+		// SDP profile test skip in ngdc-test regions
+		zone := os.Getenv("E2E_ZONE")
+		if strings.Contains(zone, "ngdc-test") {
+			condition = false
+		}
 	})
 
 	// Test 1: XFS with Tier Profile - Pod
@@ -180,7 +186,7 @@ var _ = Describe("[ics-e2e] [xfs] [sc] Dynamic Provisioning for XFS Filesystem",
 	// Test 3: XFS with SDP Profile - Pod
 	It("[xfs-sdp-pod] with XFS SDP profile: should create pvc & pv, pod resources", func() {
 		if condition == false {
-			Skip("Skipping XFS SDP test - addon version is 5.1 and SDP profile is not supported")
+			Skip("Skipping XFS SDP test - SDP profile is not supported (addon 5.1 or ngdc-test region)")
 		}
 
 		CreateStorageClass("xfs-sdp-test-sc", "sdp", "xfs", "3000", "1000", cs)
@@ -248,7 +254,7 @@ var _ = Describe("[ics-e2e] [xfs] [sc] Dynamic Provisioning for XFS Filesystem",
 	// Test 4: XFS with SDP Profile - Resize
 	It("[xfs-sdp-resize] with XFS SDP profile: should resize volume", func() {
 		if condition == false {
-			Skip("Skipping XFS SDP resize test - addon version is 5.1 and SDP profile is not supported")
+			Skip("Skipping XFS SDP resize test - SDP profile is not supported (addon 5.1 or ngdc-test region)")
 		}
 
 		CreateStorageClass("xfs-sdp-resize-sc", "sdp", "xfs", "3000", "1000", cs)


### PR DESCRIPTION
This PR improves VPC Block CSI E2E coverage and cluster provisioning reliability across IKS, ROKS/OpenShift, regular stage, and stage-us-south environments.
Key changes:
* Adds stage-us-south environment support with the correct IBM Cloud and Container Service endpoints.
* Improves cluster setup validation by checking worker states and Kubernetes node readiness before running tests.
* Adds zone-aware worker flavor selection and fallback handling when the default flavor is unavailable.
* Normalizes add-on versions for API usage and improves version gating for tests supported only by add-on 5.2.
* Fixes tier-profile StorageClass creation by cloning the cluster-installed StorageClass parameters, preserving version-specific backend configuration.
* Gates XFS SDP tests when running on unsupported 5.1 add-ons or NGDC test regions.
* Adds OpenShift-compatible pod and container security contexts, allowing SCC to assign valid UID/GID/FSGroup values instead of forcing fixed IDs.
* Improves PVC timeout diagnostics by logging PVC state, conditions, and related Kubernetes events.
* Fixes cluster cleanup, cluster-name handling, endpoint selection, and add-on installation flow.
* Improves test result reporting and add-on version parsing.